### PR TITLE
use document path as key in the protocol instead of document uri

### DIFF
--- a/ide-common/src/main/java/org/digma/intellij/plugin/psi/PsiUtils.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/psi/PsiUtils.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import org.digma.intellij.plugin.model.discovery.MethodUnderCaret;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -25,16 +26,19 @@ public class PsiUtils {
     }
 
 
-    @Nullable
-    public static PsiFile uriToPsiFile(String uri, Project project) {
+    @NotNull
+    public static PsiFile uriToPsiFile(@NotNull String uri, @NotNull Project project) {
         return ReadAction.compute(() -> {
             VirtualFile virtualFile = VirtualFileManager.getInstance().findFileByUrl(uri);
-            if (virtualFile != null) {
-                return PsiManager.getInstance(project).findFile(virtualFile);
-            }
-            return null;
+            return PsiManager.getInstance(project).findFile(virtualFile);
         });
     }
 
 
+
+
+    @NotNull
+    public static String psiFileToDocumentProtocolKey(@NotNull PsiFile psiFile){
+        return psiFile.getVirtualFile().toNioPath().toString();
+    }
 }

--- a/rider/Digma.Rider.Plugin/Digma.Rider/Discovery/DocumentMarshaller.cs
+++ b/rider/Digma.Rider.Plugin/Digma.Rider/Discovery/DocumentMarshaller.cs
@@ -11,7 +11,7 @@ namespace Digma.Rider.Discovery
     {
         public void Marshal(UnsafeWriter writer, Document value)
         {
-            writer.Write(value.Path);
+            writer.Write(value.FileUri);
             writer.Write(UnsafeWriter.StringDelegate, RiderMethodInfoWriteDelegate, value.Methods);
         }
 

--- a/rider/Digma.Rider.Plugin/Digma.Rider/Discovery/Identities.cs
+++ b/rider/Digma.Rider.Plugin/Digma.Rider/Discovery/Identities.cs
@@ -10,6 +10,12 @@ namespace Digma.Rider.Discovery
 
 
         [NotNull]
+        public static string ComputeFilePath([NotNull] IPsiSourceFile sourceFile)
+        {
+            return sourceFile.GetLocation().FullPath;
+        }   
+        
+        [NotNull]
         public static string ComputeFileUri([NotNull] IPsiSourceFile sourceFile)
         {
             return sourceFile.GetLocation().ToUri().ToString();

--- a/rider/Digma.Rider.Plugin/Digma.Rider/Logging/Logger.cs
+++ b/rider/Digma.Rider.Plugin/Digma.Rider/Logging/Logger.cs
@@ -18,14 +18,14 @@ namespace Digma.Rider.Logging
             var methodInfos = document.Methods;
             if (methodInfos.IsEmpty())
             {
-                Log(logger, "Didn't find methods for document {0}", document.Path);
+                Log(logger, "Didn't find methods for document {0}", document.FileUri);
             }
             else
             {
                 if (logger.IsInfoEnabled())
                 {
                     var methodInfosStr = string.Join("", methodInfos);
-                    Log(logger, "Found Methods for document {0}, methods: {1}", document.Path,
+                    Log(logger, "Found Methods for document {0}, methods: {1}", document.FileUri,
                         methodInfosStr);
                 }
             }

--- a/rider/Digma.Rider.Plugin/Digma.Rider/Protocol/CodeObjectsHost.cs
+++ b/rider/Digma.Rider.Plugin/Digma.Rider/Protocol/CodeObjectsHost.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Digma.Rider.Discovery;
 using JetBrains.Annotations;
 using JetBrains.Lifetimes;
 using JetBrains.Platform.RdFramework.Impl;
@@ -16,7 +17,7 @@ namespace Digma.Rider.Protocol
     public class CodeObjectsHost
     {
         // A dictionary to help us call reanalyze for specific PsiSourceFile when code lens are available.
-        private readonly Dictionary<string, IPsiSourceFile> _docToPsiSourceFile =
+        private readonly Dictionary<string, IPsiSourceFile> _docPathToPsiSourceFile =
             new Dictionary<string, IPsiSourceFile>();
 
         private readonly ShellRdDispatcher _shellRdDispatcher;
@@ -42,21 +43,21 @@ namespace Digma.Rider.Protocol
                 }
             });
             
-            _codeObjectsModel.Reanalyze.Advise(lifetime, filePath =>
+            _codeObjectsModel.Reanalyze.Advise(lifetime, documentKey =>
             {
                 using (ReadLockCookie.Create())
                 {
                     //usually we should have the PsiSourceFile so we can call ReanalyzeFile.
                     //if not found fallback to ReanalyzeAll 
-                    var psiSourceFile = _docToPsiSourceFile.TryGetValue(filePath);
+                    var psiSourceFile = _docPathToPsiSourceFile.TryGetValue(documentKey);
                     if (psiSourceFile != null && psiSourceFile.IsValid())
                     {
-                        Log(_logger,"Found PsiSourceFile for {0}, Calling ReanalyzeFile {0}",filePath,psiSourceFile);
+                        Log(_logger,"Found PsiSourceFile for {0}, Calling ReanalyzeFile {0}",documentKey,psiSourceFile);
                         riderSolutionAnalysisService.ReanalyzeFile(psiSourceFile);
                     }
                     else
                     {
-                        Log(_logger,"Could not find PsiSourceFile for {0}, Calling ReanalyzeAll",filePath);
+                        Log(_logger,"Could not find PsiSourceFile for {0}, Calling ReanalyzeAll",documentKey);
                         riderSolutionAnalysisService.ReanalyzeAll();
                     }
                 }
@@ -65,11 +66,11 @@ namespace Digma.Rider.Protocol
 
 
         [CanBeNull]
-        public RiderCodeLensInfo GetRiderCodeLensInfo([NotNull] string fqn)
+        public RiderCodeLensInfo GetRiderCodeLensInfo([NotNull] string codeObjectId)
         {
             using (ReadLockCookie.Create())
             {
-                _codeObjectsModel.CodeLens.TryGetValue(fqn, out var lensInfo);
+                _codeObjectsModel.CodeLens.TryGetValue(codeObjectId, out var lensInfo);
                 return lensInfo;
             }
         }
@@ -80,7 +81,7 @@ namespace Digma.Rider.Protocol
             if (document.Methods.IsEmpty())
                 return;
 
-            var documentPath = document.Path;
+            var documentKey = Identities.ComputeFilePath(psiSourceFile);
 
             //todo: consider removing the document from the protocol when the frontend consumes it.
             // then avoid notifying the frontend of changes if the code objects didn't change by keeping
@@ -89,40 +90,40 @@ namespace Digma.Rider.Protocol
             //relying on Equals method.
             //if the document is still in the protocol and hasn't change then do nothing.
             //if the new document is different then remove it.
-            if (document.CheckEquals(_codeObjectsModel.Documents.TryGetValue(documentPath)))
+            if (document.CheckEquals(_codeObjectsModel.Documents.TryGetValue(documentKey)))
             {
-                Log(_logger,"Document {0} already exists and is equals to the new one",documentPath);
+                Log(_logger,"Document {0} already exists and is equals to the new one",documentKey);
                 //if the document exists in the protocol then update the PsiSourceFile mapping, it can be a new instance of PsiSourceFile
                 //remove before add because it may be a new IPsiSourceFile instance
-                _docToPsiSourceFile.Remove(documentPath);
-                _docToPsiSourceFile.Add(documentPath, psiSourceFile);
+                _docPathToPsiSourceFile.Remove(documentKey);
+                _docPathToPsiSourceFile.Add(documentKey, psiSourceFile);
                 return;
             }
 
             
             //remove before add because it may be a new IPsiSourceFile instance
-            _docToPsiSourceFile.Remove(documentPath);
-            _docToPsiSourceFile.Add(documentPath, psiSourceFile);
+            _docPathToPsiSourceFile.Remove(documentKey);
+            _docPathToPsiSourceFile.Add(documentKey, psiSourceFile);
             //remove before add in case there is a non equals document already
-            Log(_logger,"Pushing Document {0} to the protocol",documentPath);
+            Log(_logger,"Pushing Document {0} to the protocol",documentKey);
             _shellRdDispatcher.UnguardedScheduler.Queue(() =>
             {
-                _codeObjectsModel.Documents.Remove(documentPath);
-                _codeObjectsModel.Documents.Add(documentPath, document);
-                NotifyOnDocumentCodeObjects(documentPath);
+                _codeObjectsModel.Documents.Remove(documentKey);
+                _codeObjectsModel.Documents.Add(documentKey, document);
+                NotifyOnDocumentCodeObjects(documentKey);
             });
         }
 
 
-        private void NotifyOnDocumentCodeObjects([NotNull] string documentPath)
+        private void NotifyOnDocumentCodeObjects([NotNull] string documentKey)
         {
             _shellRdDispatcher.UnguardedScheduler.Queue(() =>
             {
                 //maybe there where no findings for this document, don't change the value in that case
-                if (_codeObjectsModel.Documents.ContainsKey(documentPath))
+                if (_codeObjectsModel.Documents.ContainsKey(documentKey))
                 {
-                    Log(_logger,"NotifyDocumentOpened for {0}",documentPath);
-                    _codeObjectsModel.DocumentAnalyzed.Fire(documentPath);
+                    Log(_logger,"NotifyDocumentOpened for {0}",documentKey);
+                    _codeObjectsModel.DocumentAnalyzed.Fire(documentKey);
                 }
             });
         }

--- a/rider/Digma.Rider.Plugin/Digma.Rider/Protocol/ProtocolExtensions.cs
+++ b/rider/Digma.Rider.Plugin/Digma.Rider/Protocol/ProtocolExtensions.cs
@@ -17,7 +17,7 @@ namespace Digma.Rider.Protocol
             if (document == null) //satisfy resharper
                 return false;
             
-            return document.Path.Equals(other.Path) &&
+            return document.FileUri.Equals(other.FileUri) &&
                    document.Methods.Count == other.Methods.Count &&
                    !document.Methods.Except(other.Methods).Any();
         }

--- a/rider/protocol/src/main/kotlin/rider/model/CodeObjectsModel.kt
+++ b/rider/protocol/src/main/kotlin/rider/model/CodeObjectsModel.kt
@@ -36,11 +36,11 @@ class CodeObjectsModel : Ext(SolutionModel.Solution) {
         signal("reanalyzeAll", PredefinedType.void)
         signal("documentAnalyzed", PredefinedType.string)
 
-        //key: document path, value: Document
+        //key: document file path, value: Document
         map("documents",
             PredefinedType.string,
             classdef("Document") {
-                field("path",PredefinedType.string)
+                field("fileUri",PredefinedType.string)
                 //map<codeObjectId,MethodInfo>
                 map("methods", PredefinedType.string, RiderMethodInfo)
             }

--- a/rider/src/main/kotlin/org/digma/intellij/plugin/rider/protocol/DocumentCodeObjectsListener.kt
+++ b/rider/src/main/kotlin/org/digma/intellij/plugin/rider/protocol/DocumentCodeObjectsListener.kt
@@ -17,14 +17,17 @@ class DocumentCodeObjectsListener : ProjectManagerListener {
         //todo: check what can be used on solution
         project.solution.solutionLifecycle.fullStartupFinished.advise(project.lifetime) {
             val model = project.solution.codeObjectsModel
-            model.documentAnalyzed.advise(project.lifetime) { filePath ->
-                documentAnalyzed(filePath, project)
+            model.documentAnalyzed.advise(project.lifetime) { documentKey ->
+                var docUri = model.documents[documentKey]?.fileUri
+                if (docUri != null) {
+                    documentAnalyzed(docUri, project)
+                }
             }
         }
     }
 
-    private fun documentAnalyzed(filePath: String, project: Project) {
-        val psiFile = PsiUtils.uriToPsiFile(filePath, project)
+    private fun documentAnalyzed(docUri: String, project: Project) {
+        val psiFile = PsiUtils.uriToPsiFile(docUri, project)
         notifyDocumentCodeObjectsChanged(psiFile)
     }
 

--- a/rider/src/main/kotlin/org/digma/intellij/plugin/rider/protocol/protocol.kt
+++ b/rider/src/main/kotlin/org/digma/intellij/plugin/rider/protocol/protocol.kt
@@ -1,9 +1,6 @@
 @file:JvmName("Protocol")
 package org.digma.intellij.plugin.rider.protocol
 
-import com.intellij.psi.PsiFile
-import org.jetbrains.annotations.NotNull
-
 
 /*
 the backend send a file with file system protocol: file:///some/path/class.cs
@@ -19,7 +16,3 @@ we need to keep is when ever converting to and from psi file
 //    return null;
 //}
 
-@NotNull
-fun psiFileToPath(psiFile: PsiFile): String {
-    return psiFile.virtualFile.url
-}


### PR DESCRIPTION
This PR is a fix to unreliable conversions to and from fileUri to PsiFile.
so using the file's absolute path as the key for Documents in rider protocol.
the fileUri is a field in Document and is used in the frontend to locate a PsiFile