### PR TITLE
Feature/MethodInfo - no longer need idWithTypeButWithoutParams

### DIFF
--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/discovery/MethodInfo.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/discovery/MethodInfo.kt
@@ -13,7 +13,6 @@ data class MethodInfo(
 
     fun getRelatedCodeObjectIds(): List<String> {
         val relatedIds: MutableList<String> = ArrayList()
-        relatedIds.add(idWithTypeButWithoutParams())
         spans.forEach {
             relatedIds.add(it.idWithType())
         }
@@ -22,18 +21,6 @@ data class MethodInfo(
 
     override fun idWithType(): String {
         return "method:$id"
-    }
-
-    private fun idWithTypeButWithoutParams(): String {
-        return removeParamsIfNeeded(idWithType())
-    }
-
-    private fun removeParamsIfNeeded(codeObjectId: String): String {
-        val lastIndexOfOpeningParenthesis = codeObjectId.lastIndexOf('(')
-        if (lastIndexOfOpeningParenthesis >= 0) {
-            return codeObjectId.substring(0, lastIndexOfOpeningParenthesis)
-        }
-        return codeObjectId
     }
 
 }


### PR DESCRIPTION
since the following Method Overloading PRs are checked in:
[dotnet instrumentation/PR 7](https://github.com/digma-ai/OpenTelemetry.Instrumentation.Digma/pull/7#) and [Backend Collector/PR 263](https://github.com/digma-ai/digma-collector-backend/pull/263) 

no longer need to send both CodeObjectIds - sending only the relevant one - with params only.