### PR TITLE
close-error-details-when-switching-to-summary-tab

### DIFF
--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/ui/service/ToolWindowTabsHelper.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/ui/service/ToolWindowTabsHelper.kt
@@ -20,12 +20,16 @@ class ToolWindowTabsHelper(val project: Project) {
         const val SUMMARY_TAB_NAME = "summary"
     }
 
-    fun isInsightsTab(content: Content?):Boolean{
+    fun isInsightsTab(content: Content?): Boolean {
         return content != null && content.tabName.equals(INSIGHTS_TAB_NAME, ignoreCase = true)
     }
 
-    fun isErrorsTab(content: Content?):Boolean{
+    fun isErrorsTab(content: Content?): Boolean {
         return content != null && content.tabName.equals(ERRORS_TAB_NAME, ignoreCase = true)
+    }
+
+    fun isSummaryTab(content: Content?): Boolean {
+        return content != null && content.tabName.equals(SUMMARY_TAB_NAME, ignoreCase = true)
     }
 
 

--- a/src/main/java/org/digma/intellij/plugin/service/ErrorsActionsService.java
+++ b/src/main/java/org/digma/intellij/plugin/service/ErrorsActionsService.java
@@ -56,7 +56,8 @@ public class ErrorsActionsService implements ContentManagerListener {
 
     @Override
     public void selectionChanged(@NotNull ContentManagerEvent event) {
-        if (toolWindowTabsHelper.isErrorDetailsOn() && toolWindowTabsHelper.isInsightsTab(event.getContent())){
+        if (toolWindowTabsHelper.isErrorDetailsOn() &&
+                (toolWindowTabsHelper.isInsightsTab(event.getContent()) || toolWindowTabsHelper.isSummaryTab(event.getContent()))) {
             toolWindowTabsHelper.errorDetailsOff();
             errorsViewService.closeErrorDetails();
             insightsViewService.updateUi();


### PR DESCRIPTION
if error details in on and switching to summary tab the error details is not closed and the links on summary tab are un usable.
this PR closes the error details when switching to summary tab.