### PR TITLE
Feature/support jaeger external link

### DIFF
--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/LinkMode.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/LinkMode.java
@@ -1,0 +1,6 @@
+package org.digma.intellij.plugin.settings;
+
+public enum LinkMode {
+    Internal,
+    External,
+}

--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/ProjectSettings.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/ProjectSettings.java
@@ -41,7 +41,8 @@ public class ProjectSettings implements Configurable {
     @Override
     public boolean isModified() {
         SettingsState settings = SettingsState.getInstance(project);
-        return isUrlChanged(settings) || isApiTokenChanged(settings) || isRefreshDelayChanged(settings) || isJaegerUrlChanged(settings);
+        return isUrlChanged(settings) || isApiTokenChanged(settings) || isRefreshDelayChanged(settings)
+                || isJaegerUrlChanged(settings) || isJaegerLinkModeChanged(settings);
     }
 
     private boolean isRefreshDelayChanged(SettingsState settings) {
@@ -58,6 +59,10 @@ public class ProjectSettings implements Configurable {
 
     private boolean isJaegerUrlChanged(SettingsState settings) {
         return !Objects.equals(settings.jaegerUrl, mySettingsComponent.getJaegerUrl());
+    }
+
+    private boolean isJaegerLinkModeChanged(SettingsState settings) {
+        return !Objects.equals(settings.jaegerLinkMode, mySettingsComponent.getJaegerLinkMode());
     }
 
     @Override
@@ -84,6 +89,7 @@ public class ProjectSettings implements Configurable {
         settings.apiToken = theApiToken;
         settings.refreshDelay = Integer.parseInt(mySettingsComponent.getRefreshDelayText());
         settings.jaegerUrl = mySettingsComponent.getJaegerUrl();
+        settings.jaegerLinkMode = mySettingsComponent.getJaegerLinkMode();
         settings.fireChanged();
     }
 
@@ -94,6 +100,7 @@ public class ProjectSettings implements Configurable {
         mySettingsComponent.setApiToken(settings.apiToken);
         mySettingsComponent.setRefreshDelayText(String.valueOf(settings.refreshDelay));
         mySettingsComponent.setJaegerUrl(settings.jaegerUrl);
+        mySettingsComponent.setJaegerLinkMode(settings.jaegerLinkMode);
     }
 
     @Override

--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsComponent.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsComponent.java
@@ -1,6 +1,8 @@
 package org.digma.intellij.plugin.settings;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.ui.EnumComboBoxModel;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
@@ -22,6 +24,7 @@ public class SettingsComponent {
   private final JBTextField myApiToken = new JBTextField();
   private final JBTextField myRefreshDelay = new JBTextField();
   private final JBTextField myJaegerUrlText = new JBTextField();
+  private final ComboBox<LinkMode> myJaegerLinkModeComboBox = new ComboBox<>(new EnumComboBoxModel<>(LinkMode.class));
 
   public SettingsComponent(Project project) {
 
@@ -77,6 +80,7 @@ public class SettingsComponent {
       }
     });
 
+    var myJaegerLinkModeLabel = new JBLabel("Jaeger Link Mode: ");
 
     var resetButton = new JButton("Reset to defaults");
     resetButton.addActionListener(e -> resetToDefaults());
@@ -86,6 +90,7 @@ public class SettingsComponent {
             .addLabeledComponent(new JBLabel("Api token:"), myApiToken, 1, false)
             .addLabeledComponent(myRefreshLabel, myRefreshDelay, 1, false)
             .addLabeledComponent(myJaegerUrlLabel, myJaegerUrlText, 1, false)
+            .addLabeledComponent(myJaegerLinkModeLabel, myJaegerLinkModeComboBox, 1, false)
             .addComponent(resetButton)
             .addComponentFillVertically(new JPanel(), 0)
             .getPanel();
@@ -129,6 +134,14 @@ public class SettingsComponent {
     myJaegerUrlText.setText(newText.trim());
   }
 
+  public LinkMode getJaegerLinkMode() {
+    return (LinkMode) myJaegerLinkModeComboBox.getSelectedItem();
+  }
+
+  public void setJaegerLinkMode(LinkMode linkMode) {
+    myJaegerLinkModeComboBox.setSelectedItem(linkMode);
+  }
+
   @NotNull
   public String getRefreshDelayText() {
     return myRefreshDelay.getText().trim();
@@ -143,5 +156,6 @@ public class SettingsComponent {
     this.setApiToken(null);
     this.setRefreshDelayText(String.valueOf(SettingsState.DEFAULT_REFRESH_DELAY));
     this.setJaegerUrl(SettingsState.DEFAULT_JAEGER_URL);
+    this.setJaegerLinkMode(SettingsState.DEFAULT_JAEGER_LINK_MODE);
   }
 }

--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsState.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsState.java
@@ -26,12 +26,14 @@ public class SettingsState implements PersistentStateComponent<SettingsState> , 
   public static final String DEFAULT_API_URL = "https://localhost:5051";
   public static final int DEFAULT_REFRESH_DELAY = 30;
   public static final String DEFAULT_JAEGER_URL = ""; // http://localhost:16686
+  public static final LinkMode DEFAULT_JAEGER_LINK_MODE = LinkMode.Internal;
   public String apiUrl = DEFAULT_API_URL;
   public int refreshDelay = DEFAULT_REFRESH_DELAY;
   @Nullable
   public String apiToken = null;
   @Nullable
   public String jaegerUrl = DEFAULT_JAEGER_URL;
+  public LinkMode jaegerLinkMode = DEFAULT_JAEGER_LINK_MODE;
   private final List<SettingsChangeListener> listeners = new ArrayList<>();
 
   public static SettingsState getInstance(Project project) {

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/SpanPanels.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/SpanPanels.kt
@@ -1,6 +1,7 @@
 package org.digma.intellij.plugin.ui.list.insights
 
 import com.google.common.io.CharStreams
+import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBLabel
@@ -8,10 +9,21 @@ import com.intellij.ui.components.JBPanel
 import com.intellij.util.containers.isNullOrEmpty
 import com.intellij.util.ui.JBUI.Borders.empty
 import org.digma.intellij.plugin.analytics.AnalyticsService
-import org.digma.intellij.plugin.model.rest.insights.*
+import org.digma.intellij.plugin.model.rest.insights.SpanDurationsInsight
+import org.digma.intellij.plugin.model.rest.insights.SpanDurationsPercentile
+import org.digma.intellij.plugin.model.rest.insights.SpanFlow
+import org.digma.intellij.plugin.model.rest.insights.SpanInfo
+import org.digma.intellij.plugin.model.rest.insights.SpanUsagesInsight
+import org.digma.intellij.plugin.settings.LinkMode
 import org.digma.intellij.plugin.settings.SettingsState
-import org.digma.intellij.plugin.ui.common.*
+import org.digma.intellij.plugin.ui.common.CopyableLabel
+import org.digma.intellij.plugin.ui.common.CopyableLabelHtml
 import org.digma.intellij.plugin.ui.common.Html.ARROW_RIGHT
+import org.digma.intellij.plugin.ui.common.Laf
+import org.digma.intellij.plugin.ui.common.asHtml
+import org.digma.intellij.plugin.ui.common.span
+import org.digma.intellij.plugin.ui.common.spanBold
+import org.digma.intellij.plugin.ui.common.spanGrayed
 import org.digma.intellij.plugin.ui.list.ListItemActionButton
 import org.digma.intellij.plugin.ui.list.PanelsLayoutHelper
 import org.digma.intellij.plugin.ui.model.TraceSample
@@ -252,8 +264,15 @@ fun buildButtonToJaeger(
     val editorTitle = "Jaeger sample traces of Span ${spanName}"
 
     val button = ListItemActionButton(linkCaption)
-    button.addActionListener {
-        HTMLEditorProvider.openEditor(project, editorTitle,  htmlContent)
+    if (settingsState.jaegerLinkMode == LinkMode.Internal) {
+        button.addActionListener {
+            HTMLEditorProvider.openEditor(project, editorTitle, htmlContent)
+        }
+    } else {
+        // handle LinkMode.External
+        button.addActionListener {
+            BrowserUtil.browse(jaegerUrl, project)
+        }
     }
 
     return button


### PR DESCRIPTION
while preserving the Internal (embedded mode)

here's the new setting UI:
![image](https://user-images.githubusercontent.com/104715391/188316083-8425c3aa-4cd9-4671-8376-fb82eeb3ea9e.png)

I check the external link mode with logzio URL:
`https://app.logz.io/jaeger-app/`
