### PR TITLE
set limitation of text displaying for durationBreakdown insight (#203)

### DIFF
--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/DurationPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/DurationPanel.kt
@@ -32,7 +32,7 @@ fun spanDurationPanel(
     }
 
     val durationsListPanel = JBPanel<JBPanel<*>>()
-    durationsListPanel.layout = GridLayout(spanDurationsInsight.percentiles.size, 1, 0, 2)
+    durationsListPanel.layout = BoxLayout(durationsListPanel, BoxLayout.Y_AXIS)
     durationsListPanel.isOpaque = false
 
     val traceSamples = ArrayList<TraceSample>()

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/InsightsListCellRenderer.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/InsightsListCellRenderer.kt
@@ -45,7 +45,7 @@ class InsightsListCellRenderer : AbstractPanelListCellRenderer() {
             is SpanUsagesInsight -> spanUsagesPanel(project, value.modelObject as SpanUsagesInsight)
             is SpanDurationsInsight -> spanDurationPanel(project, value.modelObject as SpanDurationsInsight, panelsLayoutHelper)
             is SpanDurationBreakdownInsight -> spanDurationBreakdownPanel(project,
-                value.modelObject as SpanDurationBreakdownInsight, value.moreData, panelsLayoutHelper)
+                value.modelObject as SpanDurationBreakdownInsight, value.moreData)
             is SpanSlowEndpointsInsight -> spanSlowEndpointsPanel(project, value.modelObject as SpanSlowEndpointsInsight)
             is UnmappedInsight -> unmappedInsightPanel(project, value.modelObject as UnmappedInsight)
             else -> genericPanelForSingleInsight(project, value.modelObject)

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/SpanPanels.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/SpanPanels.kt
@@ -26,6 +26,7 @@ import java.io.InputStreamReader
 import java.sql.Timestamp
 import java.util.*
 import java.util.concurrent.TimeUnit
+import javax.swing.BoxLayout
 import javax.swing.JButton
 import javax.swing.JPanel
 import javax.swing.SwingConstants
@@ -49,7 +50,7 @@ class SpanPanels {
 fun percentileRowPanel(percentile: SpanDurationsPercentile, panelsLayoutHelper: PanelsLayoutHelper, traceSamples: ArrayList<TraceSample>): JPanel {
 
     val durationsPanel = JBPanel<JBPanel<*>>()
-    durationsPanel.layout = BorderLayout(5, 0)
+    durationsPanel.layout = BoxLayout(durationsPanel, BoxLayout.LINE_AXIS)
     durationsPanel.border = empty()
     durationsPanel.isOpaque = false
 
@@ -75,7 +76,7 @@ fun percentileRowPanel(percentile: SpanDurationsPercentile, panelsLayoutHelper: 
     pLabelPanel.isOpaque = false
     pLabelPanel.add(pLabel, BorderLayout.WEST)
     addCurrentLargestWidthDurationPLabel(panelsLayoutHelper, pLabelPanel.preferredSize.width)
-    durationsPanel.add(pLabelPanel, BorderLayout.WEST)
+    durationsPanel.add(pLabelPanel)
 
     if (needToShowDurationChange(percentile)) {
         val icon = if (percentile.previousDuration!!.raw > percentile.currentDuration.raw) Laf.Icons.Insight.SPAN_DURATION_DROPPED else Laf.Icons.Insight.SPAN_DURATION_ROSE
@@ -84,7 +85,7 @@ fun percentileRowPanel(percentile: SpanDurationsPercentile, panelsLayoutHelper: 
         val durationLabelText = asHtml(spanGrayed("$durationText,$whenText"))
         val durationLabel = JBLabel(durationLabelText, icon, SwingConstants.LEFT)
         durationLabel.toolTipText = durationLabelText
-        durationsPanel.add(durationLabel, BorderLayout.CENTER)
+        durationsPanel.add(durationLabel)
     }
 
     if (percentile.changeTime != null && (percentile.changeVerified == null || percentile.changeVerified == false)) {
@@ -98,7 +99,7 @@ fun percentileRowPanel(percentile: SpanDurationsPercentile, panelsLayoutHelper: 
         evalPanel.add(evalLabel, BorderLayout.CENTER)
         evalPanel.isOpaque = false
         addCurrentLargestWidthIconPanel(panelsLayoutHelper, evalPanel.preferredSize.width)
-        durationsPanel.add(evalPanel, BorderLayout.EAST)
+        durationsPanel.add(evalPanel)
     }
 
     return durationsPanel


### PR DESCRIPTION
New look of DurationBreakdown:
<img width="388" alt="image" src="https://user-images.githubusercontent.com/117861250/209543161-a717b352-0f50-45e7-b020-cfc951d62fa8.png">

**For now implementation has hardcoded limitation to 30 characters.**
If you have any ideas how to hide string text dynamically - please tell me your advices and tips ;)
`    if (fullDisplayName.length > 30) {
        limitedDisplayName = fullDisplayName.trim().take(30) + "..."
    }`
    
 For now I decided not to waste so much time on this fix to make it to be hidden dynamically according to user's change of panel width