### PR TITLE
IntelliJ plugin should not use popup notifications #204

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -66,7 +66,7 @@
 
 
         <notificationGroup id="Digma Notification Group"
-                           displayType="BALLOON"
+                           displayType="NONE"
                            toolWindowId="Digma"/>
 
 


### PR DESCRIPTION
Disabled displaying of popups.
New items to NOTIFICATIONS sections are being added without any issues:
<img width="373" alt="image" src="https://user-images.githubusercontent.com/117861250/209965123-d601c99f-441e-49c1-bb35-a089e172a063.png">

