### PR TITLE
#247 Implement automatic refresh + fix UI freeze on initial plugin lo…

### DIFF
--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/editor/GeneralFileEditorListener.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/editor/GeneralFileEditorListener.kt
@@ -1,0 +1,67 @@
+package org.digma.intellij.plugin.editor
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
+import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.rd.util.launchBackground
+import com.intellij.openapi.vfs.VirtualFile
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import kotlinx.coroutines.delay
+import org.digma.intellij.plugin.log.Log
+import org.digma.intellij.plugin.refreshInsightsTask.RefreshService
+
+class GeneralFileEditorListener(val project: Project) : FileEditorManagerListener {
+    private val logger: Logger = Logger.getInstance(GeneralFileEditorListener::class.java)
+
+    private val refreshService: RefreshService
+
+    // lifetimeDefinitionMap keeps info about the lifetime coroutine tasks of each opened file
+    private val lifetimeDefinitionMap: MutableMap<VirtualFile, LifetimeDefinition> = HashMap()
+    private val lifetimeDefinitionMapLock = Object()
+
+    init {
+        refreshService = project.getService(RefreshService::class.java)
+    }
+
+    override fun selectionChanged(event: FileEditorManagerEvent) {
+        super.selectionChanged(event)
+        refreshAllInsightsForActiveFile(event.oldFile, event.newFile)
+    }
+
+
+    private fun refreshAllInsightsForActiveFile(oldFile: VirtualFile?, newFile: VirtualFile?) {
+        if (newFile != null) {
+            Log.log(logger::debug, "Starting refreshAllInsightsForActiveFile = {}", newFile)
+            // lock is required here to avoid access and modification of the same map from multiple threads
+            synchronized(lifetimeDefinitionMapLock) {
+                createCoroutineTaskForActualFocusedFile(newFile)
+                terminateCoroutineTaskForPreviouslyFocusedOpenedFile(oldFile)
+            }
+            Log.log(logger::debug, "Finished refreshAllInsightsForActiveFile = {}", newFile)
+        }
+    }
+
+    private fun createCoroutineTaskForActualFocusedFile(newFile: VirtualFile) {
+        // create a lifetime for actual focused file
+        // Lifetime by itself is a lightweight and heavily optimized object. It is okay to create new lifetime on each selection change without any performance impact whatsoever.
+        val newLifetimeDefinition = LifetimeDefinition()
+        newLifetimeDefinition.lifetime.launchBackground {
+            // next logic is the Coroutine's body
+            while (true) {
+                delay(10000)// 10 seconds
+                refreshService.refreshAllForCurrentFile(newFile)
+            }
+        }
+        lifetimeDefinitionMap[newFile] = newLifetimeDefinition
+    }
+
+    private fun terminateCoroutineTaskForPreviouslyFocusedOpenedFile(oldFile: VirtualFile?) {
+        if (lifetimeDefinitionMap[oldFile] != null) {
+            // terminate the corresponding lifetime, first of all. this will also cancel current task execution
+            lifetimeDefinitionMap[oldFile]?.terminate(true)
+            // remove the lifetime for previously active file from the map
+            lifetimeDefinitionMap.remove(oldFile)
+        }
+    }
+}

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/EnvironmentsPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/EnvironmentsPanel.kt
@@ -1,5 +1,6 @@
 package org.digma.intellij.plugin.ui.common
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.ActionLink
@@ -188,10 +189,9 @@ class EnvironmentsPanel(
             val toolTip = buildToolTip(usageStatusResult, currEnv)
             val linkText = buildLinkText(currEnv, isSelectedEnv)
 
-            if (SwingUtilities.isEventDispatchThread()) {
-                buildEnvironmentsPanelButtons(currEnv, linkText, isSelectedEnv, toolTip, hasUsageFunction)
-            } else {
-                SwingUtilities.invokeLater {
+            // Please use this method instead of javax.swing.SwingUtilities.invokeLater(Runnable) or com.intellij.util.ui.UIUtil methods for the reasons described in ModalityState documentation.
+            ApplicationManager.getApplication().invokeLater {
+                Runnable {
                     buildEnvironmentsPanelButtons(currEnv, linkText, isSelectedEnv, toolTip, hasUsageFunction)
                 }
             }

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/Panels.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/Panels.kt
@@ -113,7 +113,7 @@ private fun getGeneralRefreshButton(project: Project): JButton {
     generalRefreshIconButton.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
 
     generalRefreshIconButton.addActionListener {
-        refreshService.refreshAll()
+        refreshService.refreshAllInBackground()
     }
     return generalRefreshIconButton
 }

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/InsightsCommon.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/InsightsCommon.kt
@@ -146,7 +146,6 @@ private fun rebuildPanel(
 
         if(insight.customStartTime != null || isRecalculateButtonPressed)
             bodyWrapper.add(getTimeInfoMessagePanel(
-                    insightPanel = insightPanel,
                     customStartTime = insight.customStartTime,
                     actualStartTime = insight.actualStartTime,
                     isRecalculateButtonPressed = isRecalculateButtonPressed,
@@ -175,7 +174,6 @@ private fun rebuildPanel(
 }
 
 private fun getTimeInfoMessagePanel(
-        insightPanel: DigmaResettablePanel,
         customStartTime: Date?,
         actualStartTime: Date?,
         isRecalculateButtonPressed: Boolean,
@@ -205,7 +203,7 @@ private fun getTimeInfoMessagePanel(
     timeInfoMessageLabelPanel.isOpaque = false
     timeInfoMessageLabelPanel.add(timeInfoMessageLabel)
     if (shouldShowApplyNewTimeFilterLabel(isRecalculateButtonPressed, identicalStartTimes)) {
-        timeInfoMessageLabelPanel.add(getRefreshInsightButton(insightPanel, project))
+        timeInfoMessageLabelPanel.add(getRefreshInsightButton(project))
     }
     return timeInfoMessageLabelPanel
 }
@@ -324,12 +322,11 @@ private fun showHintMessage(
     HintManager.getInstance().showHint(recalculateAction, RelativePoint.getSouthWestOf(threeDotsIcon), HintManager.HIDE_BY_ESCAPE, 2000)
 }
 
-private fun getRefreshInsightButton(insightPanel: DigmaResettablePanel, project: Project): ActionLink {
+private fun getRefreshInsightButton(project: Project): ActionLink {
     val refreshAction = ActionLink(REFRESH)
     refreshAction.addActionListener {
         val refreshService: RefreshService = project.getService(RefreshService::class.java)
-        refreshService.refreshAll()
-        rebuildInsightPanel(insightPanel)
+        refreshService.refreshAllInBackground()
     }
     refreshAction.border = empty()
     refreshAction.isOpaque = false
@@ -354,34 +351,6 @@ fun genericPanelForSingleInsight(project: Project, modelObject: Any?): JPanel {
             paginationComponent = null
     )
 }
-
-
-
-
-
-internal fun insightsIconPanelBorder(icon: Icon, text: String, panelsLayoutHelper: PanelsLayoutHelper): JPanel {
-
-    val panel = InsightAlignedPanel(panelsLayoutHelper)
-    panel.layout = BorderLayout()
-    panel.isOpaque = false
-    panel.border = empty(2,0,0, getInsightIconPanelRightBorderSize())
-
-    val iconLabel = JLabel(icon)
-    iconLabel.horizontalAlignment = SwingConstants.CENTER
-    panel.add(iconLabel, BorderLayout.CENTER)
-
-    if (text.isNotBlank()) {
-        val textLabel = JLabel(text)
-        textLabel.horizontalAlignment = SwingConstants.CENTER
-        panel.add(textLabel, BorderLayout.SOUTH)
-    }
-
-    addCurrentLargestWidthIconPanel(panelsLayoutHelper,panel.preferredSize.width)
-
-    return panel
-}
-
-
 
 
 internal fun getInsightIconPanelRightBorderSize():Int{

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -95,8 +95,12 @@
         <listener
                 class="org.digma.intellij.plugin.emvironment.EnvironmentChangeHandler"
                 topic="org.digma.intellij.plugin.analytics.EnvironmentChanged"/>
-        <listener class="org.digma.intellij.plugin.debugger.DebuggerListener"
-                  topic="com.intellij.xdebugger.XDebuggerManagerListener"/>
+        <listener
+                class="org.digma.intellij.plugin.debugger.DebuggerListener"
+                topic="com.intellij.xdebugger.XDebuggerManagerListener"/>
+        <listener
+                class="org.digma.intellij.plugin.editor.GeneralFileEditorListener"
+                topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
     </projectListeners>
 
 


### PR DESCRIPTION
Fixes #247
* implemented automatic refresh
* fixed UI freeze in initial load of Digma (fixed reload of summaries panel)


Automatic refresh is being executed each 10 seconds ONLY for active file.

Automatic refresh was implemented with help of` Kotlin Coroutines` and `lifetime`s (because Java background thread are heavy).
We create a `lifetime` for actual focused file
Lifetime by itself is a lightweight and heavily optimized object. It is okay to create new lifetime on each selection change without any performance impact whatsoever.  (Consulted with Jetbrains developer).

LIFETIME is more or less simple class (https://github.com/JetBrains/rd/blob/ec794823a473e7abff65d969cb70e70ade9ec057/rd-kt/rd-core/src/main/kotlin/com/jetbrains/rd/util/lifetime/RLifetime.kt) that allows to collect actions and then execute them on lifetime termination. You may conceptually assign a lifetime to anything, and perform operations on said lifetime (attach stuff to it, and expect it to be executed when the lifetime terminates).
Some of objects in Rider already have their assigned lifetimes (such as `project.lifetime` or some `LifetimedService.lifetime`).


So in scope of this task `lifetime` was use to execute `refreshAllForCurrentFile` **_Coroutine task_**.

