### PR TITLE
#278 Fix EnvironmentsPanel duplication

### DIFF
--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/EnvironmentsPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/EnvironmentsPanel.kt
@@ -1,6 +1,5 @@
 package org.digma.intellij.plugin.ui.common
 
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.ActionLink
@@ -189,11 +188,8 @@ class EnvironmentsPanel(
             val toolTip = buildToolTip(usageStatusResult, currEnv)
             val linkText = buildLinkText(currEnv, isSelectedEnv)
 
-            // Please use this method instead of javax.swing.SwingUtilities.invokeLater(Runnable) or com.intellij.util.ui.UIUtil methods for the reasons described in ModalityState documentation.
-            ApplicationManager.getApplication().invokeLater {
-                Runnable {
-                    buildEnvironmentsPanelButtons(currEnv, linkText, isSelectedEnv, toolTip, hasUsageFunction)
-                }.run()
+            SwingUtilities.invokeLater {
+                buildEnvironmentsPanelButtons(currEnv, linkText, isSelectedEnv, toolTip, hasUsageFunction)
             }
         }
         revalidate()


### PR DESCRIPTION
Fixes #278 

Used _SwingUtilities.invokeLater_ instead of _ApplicationManager.getApplication().invokeLater_ as last one provides duplication problem