### PR TITLE
Feature/Add SpanInfo to SpanInsights - as in backend

### DIFF
--- a/ide-common/src/main/java/org/digma/intellij/plugin/insights/view/BuildersHolder.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/insights/view/BuildersHolder.java
@@ -1,7 +1,22 @@
 package org.digma.intellij.plugin.insights.view;
 
 import org.digma.intellij.plugin.model.InsightType;
-import org.digma.intellij.plugin.model.rest.insights.*;
+import org.digma.intellij.plugin.model.rest.insights.CodeObjectInsight;
+import org.digma.intellij.plugin.model.rest.insights.EPNPlusSpansInsight;
+import org.digma.intellij.plugin.model.rest.insights.ErrorInsight;
+import org.digma.intellij.plugin.model.rest.insights.HighUsageInsight;
+import org.digma.intellij.plugin.model.rest.insights.HotspotInsight;
+import org.digma.intellij.plugin.model.rest.insights.LowUsageInsight;
+import org.digma.intellij.plugin.model.rest.insights.NormalUsageInsight;
+import org.digma.intellij.plugin.model.rest.insights.SlowEndpointInsight;
+import org.digma.intellij.plugin.model.rest.insights.SlowestSpansInsight;
+import org.digma.intellij.plugin.model.rest.insights.SpanDurationBreakdownInsight;
+import org.digma.intellij.plugin.model.rest.insights.SpanDurationsInsight;
+import org.digma.intellij.plugin.model.rest.insights.SpanNPlusOneInsight;
+import org.digma.intellij.plugin.model.rest.insights.SpanScalingInsight;
+import org.digma.intellij.plugin.model.rest.insights.SpanSlowEndpointsInsight;
+import org.digma.intellij.plugin.model.rest.insights.SpanUsagesInsight;
+import org.digma.intellij.plugin.model.rest.insights.UnmappedInsight;
 import org.digma.intellij.plugin.ui.model.insights.InsightGroupType;
 import org.digma.intellij.plugin.view.EmptyListViewItemBuilder;
 import org.digma.intellij.plugin.view.ListViewItemBuilder;
@@ -36,29 +51,29 @@ public class BuildersHolder {
             case Errors:
                 return new NoGroupListViewItemBuilder<ErrorInsight>();
             case SpanUsages:
-                return new GroupListViewItemBuilder<SpanUsagesInsight>(InsightGroupType.Span, null, SpanUsagesInsight::getSpan);
+                return new GroupListViewItemBuilder<SpanUsagesInsight>(InsightGroupType.Span, null, SpanUsagesInsight::spanName);
             case SpanDurations:
-                return new GroupListViewItemBuilder<SpanDurationsInsight>(InsightGroupType.Span, null, spanDurationsInsight -> spanDurationsInsight.getSpan().getName());
+                return new GroupListViewItemBuilder<SpanDurationsInsight>(InsightGroupType.Span, null, spanDurationsInsight -> spanDurationsInsight.spanName());
             case SpanScaling:
-                return new GroupListViewItemBuilder<SpanScalingInsight>(InsightGroupType.Span, null, SpanScalingInsight::getSpanName);
+                return new GroupListViewItemBuilder<SpanScalingInsight>(InsightGroupType.Span, null, SpanScalingInsight::spanName);
             case SpanDurationBreakdown:
-                return new GroupListViewItemBuilder<SpanDurationBreakdownInsight>(InsightGroupType.Span, null, SpanDurationBreakdownInsight::getSpanName);
+                return new GroupListViewItemBuilder<SpanDurationBreakdownInsight>(InsightGroupType.Span, null, SpanDurationBreakdownInsight::spanName);
             case SpanEndpointBottleneck:
-                return new GroupListViewItemBuilder<SpanSlowEndpointsInsight>(InsightGroupType.Span, null, insight -> insight.getSpan().getName());
+                return new GroupListViewItemBuilder<SpanSlowEndpointsInsight>(InsightGroupType.Span, null, insight -> insight.spanName());
             case SpaNPlusOne:
-                return new GroupListViewItemBuilder<SpanNPlusOneInsight>(InsightGroupType.Span, null, insight -> insight.getSpan().getName());
+                return new GroupListViewItemBuilder<SpanNPlusOneInsight>(InsightGroupType.Span, null, insight -> insight.spanName());
             case SlowestSpans:
-                return new GroupListViewItemBuilder<SlowestSpansInsight>(InsightGroupType.HttpEndpoint, SlowestSpansInsight::getRoute, SlowestSpansInsight::getEndpointSpan);
+                return new GroupListViewItemBuilder<SlowestSpansInsight>(InsightGroupType.HttpEndpoint, SlowestSpansInsight::getRoute, SlowestSpansInsight::endpointSpanName);
             case LowUsage:
-                return new GroupListViewItemBuilder<LowUsageInsight>(InsightGroupType.HttpEndpoint, LowUsageInsight::getRoute, LowUsageInsight::getEndpointSpan);
+                return new GroupListViewItemBuilder<LowUsageInsight>(InsightGroupType.HttpEndpoint, LowUsageInsight::getRoute, LowUsageInsight::endpointSpanName);
             case NormalUsage:
-                return new GroupListViewItemBuilder<NormalUsageInsight>(InsightGroupType.HttpEndpoint, NormalUsageInsight::getRoute, NormalUsageInsight::getEndpointSpan);
+                return new GroupListViewItemBuilder<NormalUsageInsight>(InsightGroupType.HttpEndpoint, NormalUsageInsight::getRoute, NormalUsageInsight::endpointSpanName);
             case HighUsage:
-                return new GroupListViewItemBuilder<HighUsageInsight>(InsightGroupType.HttpEndpoint, HighUsageInsight::getRoute, HighUsageInsight::getEndpointSpan);
+                return new GroupListViewItemBuilder<HighUsageInsight>(InsightGroupType.HttpEndpoint, HighUsageInsight::getRoute, HighUsageInsight::endpointSpanName);
             case SlowEndpoint:
-                return new GroupListViewItemBuilder<SlowEndpointInsight>(InsightGroupType.HttpEndpoint, SlowEndpointInsight::getRoute, SlowEndpointInsight::getEndpointSpan);
+                return new GroupListViewItemBuilder<SlowEndpointInsight>(InsightGroupType.HttpEndpoint, SlowEndpointInsight::getRoute, SlowEndpointInsight::endpointSpanName);
             case EndpointSpaNPlusOne:
-                return new GroupListViewItemBuilder<EPNPlusSpansInsight>(InsightGroupType.HttpEndpoint, EPNPlusSpansInsight::getRoute, EPNPlusSpansInsight::getEndpointSpan);
+                return new GroupListViewItemBuilder<EPNPlusSpansInsight>(InsightGroupType.HttpEndpoint, EPNPlusSpansInsight::getRoute, EPNPlusSpansInsight::endpointSpanName);
             case Unmapped:
                 return new NoGroupListViewItemBuilder<UnmappedInsight>();
             default:

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/EPNPlusSpansInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/EPNPlusSpansInsight.kt
@@ -1,10 +1,13 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+//TODO: rename to EndpointSuspectedNPlusOne
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class EPNPlusSpansInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @ConstructorProperties(
@@ -13,12 +16,13 @@ data class EPNPlusSpansInsight
         "scope",
         "importance",
         "decorators",
-        "route",
-        "endpointSpan",
         "actualStartTime",
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
+        "route",
+        "serviceName",
         "spans"
 )
 constructor(
@@ -27,13 +31,14 @@ constructor(
         override val scope: String,
         override val importance: Int,
         override val decorators: List<CodeObjectDecorator>?,
-        override var route: String,
-        override var endpointSpan: String,
         override val actualStartTime: Date?,
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
+        override var route: String,
+        override var serviceName: String,
         val spans: List<HighlyOccurringSpanInfo>,
 ) : EndpointInsight {
-        override val type: InsightType = InsightType.EndpointSpaNPlusOne
+    override val type: InsightType = InsightType.EndpointSpaNPlusOne
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/EndpointInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/EndpointInsight.kt
@@ -1,6 +1,10 @@
 package org.digma.intellij.plugin.model.rest.insights
 
-interface EndpointInsight : CodeObjectInsight {
+interface EndpointInsight : SpanInsight {
     var route: String
-    var endpointSpan: String
+    var serviceName: String
+
+    fun endpointSpanName(): String {
+        return spanInfo.name
+    }
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/HighUsageInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/HighUsageInsight.kt
@@ -1,10 +1,12 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class HighUsageInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @ConstructorProperties(
@@ -13,12 +15,13 @@ data class HighUsageInsight
         "scope",
         "importance",
         "decorators",
-        "route",
-        "endpointSpan",
         "actualStartTime",
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
+        "route",
+        "serviceName",
         "maxCallsIn1Min")
 constructor(
         override val codeObjectId: String,
@@ -26,12 +29,13 @@ constructor(
         override val scope: String,
         override val importance: Int,
         override val decorators: List<CodeObjectDecorator>?,
-        override var route: String,
-        override var endpointSpan: String,
         override val actualStartTime: Date?,
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
+        override var route: String,
+        override var serviceName: String,
         val maxCallsIn1Min: Int,
 ) : EndpointInsight {
     override val type: InsightType = InsightType.HighUsage

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/LowUsageInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/LowUsageInsight.kt
@@ -1,10 +1,12 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class LowUsageInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @ConstructorProperties(
@@ -13,12 +15,13 @@ data class LowUsageInsight
         "scope",
         "importance",
         "decorators",
-        "route",
-        "endpointSpan",
         "actualStartTime",
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
+        "route",
+        "serviceName",
         "maxCallsIn1Min"
 )
 constructor(
@@ -27,12 +30,13 @@ constructor(
         override val scope: String,
         override val importance: Int,
         override val decorators: List<CodeObjectDecorator>?,
-        override var route: String,
-        override var endpointSpan: String,
         override val actualStartTime: Date?,
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
+        override var route: String,
+        override var serviceName: String,
         val maxCallsIn1Min: Int,
 ) : EndpointInsight {
     override val type: InsightType = InsightType.LowUsage

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/NormalUsageInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/NormalUsageInsight.kt
@@ -1,10 +1,12 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class NormalUsageInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @ConstructorProperties(
@@ -13,12 +15,13 @@ data class NormalUsageInsight
         "scope",
         "importance",
         "decorators",
-        "route",
-        "endpointSpan",
         "actualStartTime",
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
+        "route",
+        "serviceName",
         "maxCallsIn1Min"
 )
 constructor(
@@ -27,12 +30,13 @@ constructor(
         override val scope: String,
         override val importance: Int,
         override val decorators: List<CodeObjectDecorator>?,
-        override var route: String,
-        override var endpointSpan: String,
         override val actualStartTime: Date?,
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
+        override var route: String,
+        override var serviceName: String,
         val maxCallsIn1Min: Int,
 ) : EndpointInsight {
     override val type: InsightType = InsightType.NormalUsage

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SlowEndpointInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SlowEndpointInsight.kt
@@ -1,10 +1,12 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SlowEndpointInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @ConstructorProperties(
@@ -13,12 +15,13 @@ data class SlowEndpointInsight
         "scope",
         "importance",
         "decorators",
-        "route",
-        "endpointSpan",
         "actualStartTime",
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
+        "route",
+        "serviceName",
         "endpointsMedian",
         "endpointsMedianOfMedians",
         "endpointsMedianOfP75",
@@ -37,12 +40,13 @@ constructor(
         override val scope: String,
         override val importance: Int,
         override val decorators: List<CodeObjectDecorator>?,
-        override var route: String,
-        override var endpointSpan: String,
         override val actualStartTime: Date?,
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
+        override var route: String,
+        override var serviceName: String,
         val endpointsMedian: Duration,
         val endpointsMedianOfMedians: Duration,
         val endpointsMedianOfP75: Duration,

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SlowestSpansInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SlowestSpansInsight.kt
@@ -1,10 +1,12 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SlowestSpansInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @ConstructorProperties(
@@ -13,12 +15,13 @@ data class SlowestSpansInsight
         "scope",
         "importance",
         "decorators",
-        "route",
-        "endpointSpan",
         "actualStartTime",
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
+        "route",
+        "serviceName",
         "spans"
 )
 constructor(
@@ -27,12 +30,13 @@ constructor(
         override val scope: String,
         override val importance: Int,
         override val decorators: List<CodeObjectDecorator>?,
-        override var route: String,
-        override var endpointSpan: String,
         override val actualStartTime: Date?,
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
+        override var route: String,
+        override var serviceName: String,
         val spans: List<SlowSpanInfo>,
 ) : EndpointInsight {
     override val type: InsightType = InsightType.SlowestSpans

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanDurationBreakdownInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanDurationBreakdownInsight.kt
@@ -1,10 +1,9 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import org.digma.intellij.plugin.model.InsightImportance
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
 data class SpanDurationBreakdownInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -18,6 +17,7 @@ data class SpanDurationBreakdownInsight
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
         "spanName",
         "breakdownEntries"
 )
@@ -31,9 +31,10 @@ constructor(
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
         val spanName: String,
         val breakdownEntries: List<SpanDurationBreakdown>,
-) : CodeObjectInsight {
+) : SpanInsight {
 
     override val type: InsightType = InsightType.SpanDurationBreakdown
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanDurationsInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanDurationsInsight.kt
@@ -1,10 +1,9 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import org.digma.intellij.plugin.model.InsightImportance
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
 data class SpanDurationsInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -18,7 +17,7 @@ data class SpanDurationsInsight
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
-        "span",
+        "spanInfo",
         "percentiles"
 )
 constructor(
@@ -31,9 +30,9 @@ constructor(
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
-        val span: SpanInfo,
+        override val spanInfo: SpanInfo,
         val percentiles: List<SpanDurationsPercentile>,
-) : CodeObjectInsight {
+) : SpanInsight {
 
     override val type: InsightType = InsightType.SpanDurations
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanInfo.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanInfo.kt
@@ -4,12 +4,23 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import java.beans.ConstructorProperties
 
+// SpanInfo attached to SpanInsight
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SpanInfo
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-@ConstructorProperties("instrumentationLibrary", "name", "displayName", "serviceName", "codeObjectId")
-constructor(val instrumentationLibrary: String,
-            val name: String,
-            val displayName: String?,
-            val serviceName: String?,
-            val codeObjectId: String?)
+@ConstructorProperties(
+        "instrumentationLibrary",
+        "name",
+        "spanCodeObjectId",
+        "displayName",
+        "methodCodeObjectId",
+        "kind",
+)
+constructor(
+        val instrumentationLibrary: String,
+        val name: String,
+        val spanCodeObjectId: String?, //TODO: should be not null, somehow the backend returns nulls on endpoints
+        val displayName: String,
+        val methodCodeObjectId: String?,
+        val kind: String,
+)

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanInsight.kt
@@ -1,0 +1,10 @@
+package org.digma.intellij.plugin.model.rest.insights
+
+interface SpanInsight : CodeObjectInsight {
+    // scope = "Span"
+    val spanInfo: SpanInfo
+
+    fun spanName(): String {
+        return spanInfo.name
+    }
+}

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanNPlusOneInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanNPlusOneInsight.kt
@@ -3,7 +3,7 @@ package org.digma.intellij.plugin.model.rest.insights
 import com.fasterxml.jackson.annotation.JsonCreator
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
 class SpanNPlusOneInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -17,8 +17,8 @@ class SpanNPlusOneInsight
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
         "traceId",
-        "span",
         "clientSpanName",
         "occurrences",
         "duration",
@@ -34,12 +34,12 @@ constructor(
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
         val traceId: String?,
-        val span: SpanInfo,
         val clientSpanName: String?,
         val occurrences: Number,
         val duration: Duration,
         val endpoints: List<SpanNPlusEndpoints>,
-) : CodeObjectInsight {
+) : SpanInsight {
     override val type: InsightType = InsightType.SpaNPlusOne
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanScalingInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanScalingInsight.kt
@@ -3,8 +3,7 @@ package org.digma.intellij.plugin.model.rest.insights
 import com.fasterxml.jackson.annotation.JsonCreator
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
-import kotlin.collections.ArrayList
+import java.util.Date
 
 data class SpanScalingInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -18,6 +17,7 @@ data class SpanScalingInsight
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
         "spanName",
         "spanInstrumentationLibrary",
         "turningPointConcurrency",
@@ -36,6 +36,7 @@ constructor(
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
         val spanName: String,
         val spanInstrumentationLibrary: String,
         val turningPointConcurrency: Int,
@@ -43,7 +44,7 @@ constructor(
         val minDuration: Duration,
         val maxDuration: Duration,
         val rootCauseSpans: List<RootCauseSpan> = ArrayList()
-) : CodeObjectInsight {
+) : SpanInsight {
 
     override val type: InsightType = InsightType.SpanScaling
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanSlowEndpointsInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanSlowEndpointsInsight.kt
@@ -2,11 +2,11 @@ package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import org.digma.intellij.plugin.model.InsightImportance
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
+// TODO: rename to SpanEndpointsBottleneckInsight
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SpanSlowEndpointsInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -20,7 +20,7 @@ data class SpanSlowEndpointsInsight
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
-        "span",
+        "spanInfo",
         "slowEndpoints"
 )
 constructor(
@@ -33,8 +33,8 @@ constructor(
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
-        val span: SpanInfo,
+        override val spanInfo: SpanInfo,
         val slowEndpoints: List<SlowEndpointInfo>,
-) : CodeObjectInsight {
+) : SpanInsight {
     override val type: InsightType = InsightType.SpanEndpointBottleneck
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanUsagesInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanUsagesInsight.kt
@@ -1,10 +1,9 @@
 package org.digma.intellij.plugin.model.rest.insights
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import org.digma.intellij.plugin.model.InsightImportance
 import org.digma.intellij.plugin.model.InsightType
 import java.beans.ConstructorProperties
-import java.util.*
+import java.util.Date
 
 data class SpanUsagesInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
@@ -18,6 +17,7 @@ data class SpanUsagesInsight
         "customStartTime",
         "prefixedCodeObjectId",
         "shortDisplayInfo",
+        "spanInfo",
         "span",
         "flows"
 )
@@ -31,9 +31,10 @@ constructor(
         override val customStartTime: Date?,
         override val prefixedCodeObjectId: String?,
         override val shortDisplayInfo: ShortDisplayInfo?,
+        override val spanInfo: SpanInfo,
         val span: String,
         val flows: List<SpanFlow>,
-) : CodeObjectInsight {
+) : SpanInsight {
 
     override val type: InsightType = InsightType.SpanUsages
 }

--- a/model/src/test/kotlin/org/digma/intellij/plugin/model/rest/insights/EndpointSchemaTest.kt
+++ b/model/src/test/kotlin/org/digma/intellij/plugin/model/rest/insights/EndpointSchemaTest.kt
@@ -3,7 +3,7 @@ package org.digma.intellij.plugin.model.rest.insights
 import org.digma.intellij.plugin.model.rest.insights.EndpointSchema.Companion.adjustHttpRouteIfNeeded
 import org.digma.intellij.plugin.model.rest.insights.EndpointSchema.Companion.getRouteInfo
 import java.time.temporal.ChronoUnit
-import java.util.*
+import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,7 +30,9 @@ internal class EndpointSchemaTest {
     @Test
     fun adjustHttpRouteIfNeededShouldAdjustWhenNoSchema() {
         val codeObjectId = "123"
-        val normalUsageInsight = NormalUsageInsight(codeObjectId, "env1", "scope1", 3, null, "get /yes", "endpointSpan1", actualStartTimeNow, customStartTimeFiveDaysBefore, addPrefixToCodeObjectId(codeObjectId), null, 3)
+        val normalUsageInsight = NormalUsageInsight(codeObjectId, "env1", "scope1", 3, null, actualStartTimeNow, customStartTimeFiveDaysBefore, addPrefixToCodeObjectId(codeObjectId), null,
+                createSpanInfo("endpointSpan1"), "get /yes", "myService",
+                3)
         adjustHttpRouteIfNeeded(normalUsageInsight)
         assertEquals("get /yes", normalUsageInsight.route)
     }
@@ -38,7 +40,9 @@ internal class EndpointSchemaTest {
     @Test
     fun adjustHttpRouteIfNeededShouldSkipAdjustWhenHttpSchemaAlreadyExists() {
         val codeObjectId = "456"
-        val normalUsageInsight = NormalUsageInsight(codeObjectId, "env2", "scope2", 2, null, "epHTTP:post /letsgo", "endpointSpan2", actualStartTimeNow, customStartTimeFiveDaysBefore, addPrefixToCodeObjectId(codeObjectId), null, 8)
+        val normalUsageInsight = NormalUsageInsight(codeObjectId, "env2", "scope2", 2, null, actualStartTimeNow, customStartTimeFiveDaysBefore, addPrefixToCodeObjectId(codeObjectId), null,
+                createSpanInfo("endpointSpan1"), "epHTTP:post /letsgo", "myService",
+                8)
         adjustHttpRouteIfNeeded(normalUsageInsight)
         assertEquals("epHTTP:post /letsgo", normalUsageInsight.route)
     }
@@ -46,9 +50,16 @@ internal class EndpointSchemaTest {
     @Test
     fun adjustHttpRouteIfNeededShouldSkipAdjustWhenRpcSchemaAlreadyExists() {
         val codeObjectId = "789"
-        val normalUsageInsight = NormalUsageInsight(codeObjectId, "env3", "scope3", 5, null, "epRPC:serviceA.methodB", "endpointSpan3", actualStartTimeNow, customStartTimeFiveDaysBefore, addPrefixToCodeObjectId(codeObjectId), null, 4)
+        val normalUsageInsight = NormalUsageInsight(codeObjectId, "env3", "scope3", 5, null, actualStartTimeNow, customStartTimeFiveDaysBefore, addPrefixToCodeObjectId(codeObjectId), null,
+                createSpanInfo("endpointSpan3"), "epRPC:serviceA.methodB", "MyService",
+                4)
         adjustHttpRouteIfNeeded(normalUsageInsight)
         assertEquals("epRPC:serviceA.methodB", normalUsageInsight.route)
+    }
+
+    private fun createSpanInfo(spanName: String): SpanInfo {
+        val instLib = "il"
+        return SpanInfo(instLib, spanName, "span:$instLib\$_\$$spanName", "disp_$spanName", null, "Internal")
     }
 
     private fun addPrefixToCodeObjectId(codeObjectId: String): String {

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/DurationPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/DurationPanel.kt
@@ -4,8 +4,11 @@ import com.intellij.openapi.fileEditor.impl.HTMLEditorProvider
 import com.intellij.openapi.project.Project
 import com.intellij.ui.components.JBPanel
 import org.digma.intellij.plugin.analytics.AnalyticsService
-import org.digma.intellij.plugin.model.rest.insights.*
-import org.digma.intellij.plugin.ui.common.*
+import org.digma.intellij.plugin.model.rest.insights.SpanDurationsInsight
+import org.digma.intellij.plugin.model.rest.insights.SpanDurationsPercentile
+import org.digma.intellij.plugin.model.rest.insights.SpanInfo
+import org.digma.intellij.plugin.ui.common.Laf
+import org.digma.intellij.plugin.ui.common.getHex
 import org.digma.intellij.plugin.ui.list.ListItemActionButton
 import org.digma.intellij.plugin.ui.list.PanelsLayoutHelper
 import org.digma.intellij.plugin.ui.model.TraceSample
@@ -45,8 +48,8 @@ fun spanDurationPanel(
                 durationsListPanel.add(durationsPanel)
             }
 
-    val buttonToGraph = buildButtonToPercentilesGraph(project, spanDurationsInsight.span)
-    val buttonToJaeger = buildButtonToJaeger(project, "Compare", spanDurationsInsight.span.name, traceSamples)
+    val buttonToGraph = buildButtonToPercentilesGraph(project, spanDurationsInsight.spanInfo)
+    val buttonToJaeger = buildButtonToJaeger(project, "Compare", spanDurationsInsight.spanInfo.name, traceSamples)
 
     return createInsightPanel(
             project = project,

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/EPNPlusSpansPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/list/insights/EPNPlusSpansPanel.kt
@@ -166,7 +166,7 @@ private fun nPOneSpanRowPanel(span: HighlyOccurringSpanInfo, project: Project, m
 }
 
 private fun getButtonToJaeger(project: Project, insight: EPNPlusSpansInsight): JButton? {
-    val spanName = insight.endpointSpan
+    val spanName = insight.endpointSpanName()
     val sampleTraceId = insight.spans.first().traceId
     val traceSample = TraceSample(spanName, sampleTraceId)
     return buildButtonToJaeger(project, "Trace", spanName, listOf(traceSample))


### PR DESCRIPTION
also Align insight span info as in backend

see backend definitions:
* SpanInsight - https://github.com/digma-ai/digma-collector-backend/blob/main/src/Contracts/Digma.Contracts/CodeObject/CodeObjectInsight.cs#L235

* SpanInfo - https://github.com/digma-ai/digma-collector-backend/blob/main/src/Contracts/Digma.Contracts/CodeObject/CodeObjectInsight.cs#L345

* EndpointInsight - https://github.com/digma-ai/digma-collector-backend/blob/main/src/Contracts/Digma.Contracts/CodeObject/CodeObjectInsight.cs#L242


this is Preparation PR before addressing #389, since need common access to SpanName