### PR TITLE
Fixed Rider is not responding #311

### DIFF
--- a/ide-common/src/main/java/org/digma/intellij/plugin/document/DocumentInfoService.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/document/DocumentInfoService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -48,8 +49,9 @@ public class DocumentInfoService {
      * there are situations where intellij may decide to reparse a psi tree and in that case the psi file may not
      * be valid anymore, the instance in intellij indexes will change. so we use the file uri as key and always convert
      * from PsiFile to uri when necessary.
+     * By using ConcurrentHashMap, we can avoid blocking the UI thread and improve the concurrency of our application.
      */
-    private final Map<String, DocumentInfoContainer> documents = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, DocumentInfoContainer> documents = new ConcurrentHashMap<>();
 
     //dominantLanguages keeps track of the most used programming language in the documents. it is used to decide which
     // language service to use when we don't have a method info.

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/EnvironmentsDropdownPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/EnvironmentsDropdownPanel.kt
@@ -245,7 +245,7 @@ class EnvironmentsDropdownPanel(
         })
 
         comboBox.addActionListener { event ->
-            val cb = event.source as ComboBox<String>
+            val cb = event.source as ComboBox<*>
             var selectedEnv = cb.selectedItem as String?  // can be null if connection error and all item being removed from list (current logic)
             if (selectedEnv == null || selectedEnv == NO_ENVIRONMENTS_MESSAGE) return@addActionListener
             selectedEnv = adjustBackEnvNameIfNeeded(selectedEnv)


### PR DESCRIPTION
Fixes #311 

After investigation of logs from Shay's machine I figured out that root cause of this problem was `DocumentInfoService`:
`    private final Map<String, DocumentInfoContainer> documents = Collections.synchronizedMap(new HashMap<>());`

The thread calling the `removeDocumentInfo` method was blocked waiting to acquire the lock of the `synchronized` map.

To improve this, I used a concurrent map implementation (`ConcurrentHashMap`) instead of a `synchronized` map. This will allow multiple threads to access the map concurrently without blocking each other.

By using `ConcurrentHashMap`, we can avoid blocking the UI thread and improve the concurrency of our application.