### PR TITLE
add importance to SlimAggregatedInsight

### DIFF
--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/recentactivity/RecentActivityResult.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/recentactivity/RecentActivityResult.kt
@@ -52,9 +52,10 @@ constructor(
 data class SlimAggregatedInsight
 @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ConstructorProperties("type", "codeObjectIds")
+@ConstructorProperties("type", "importance", "codeObjectIds")
 constructor(
         val type: String,
+        val importance: Int,
         val codeObjectIds: List<String>
 )
 

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/recentactivity/RecentActivityResult.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/recentactivity/RecentActivityResult.kt
@@ -55,7 +55,7 @@ data class SlimAggregatedInsight
 @ConstructorProperties("type", "importance", "codeObjectIds")
 constructor(
         val type: String,
-        val importance: Int,
+        val importance: Int, // value of zero means that backend is still not up to date(forward compatibility)
         val codeObjectIds: List<String>
 )
 


### PR DESCRIPTION
this is related to colorized insight icon in recent activity, please note that importance equals 0 means that the backend is not updated yet.
so in such case, we can have no colored icons as today

goes together with backend PR https://github.com/digma-ai/digma-collector-backend/pull/833