### PR TITLE
Bugfix/temp guide files - delete on exit - based on entire folder

### DIFF
--- a/src/main/java/org/digma/intellij/plugin/service/EditorService.java
+++ b/src/main/java/org/digma/intellij/plugin/service/EditorService.java
@@ -4,6 +4,7 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
@@ -154,8 +155,14 @@ public class EditorService implements Disposable {
         return FileEditorManager.getInstance(project).openTextEditor(navigable, true);
     }
 
-    public void openVirtualFile(@NotNull VirtualFile virtualFile) {
-        openVirtualFile(virtualFile, 1);
+    public void openVirtualFile(@NotNull VirtualFile virtualFile, boolean readOnly) {
+        Editor editor = openVirtualFile(virtualFile, 1);
+        if (readOnly) {
+            if (editor instanceof EditorEx) {
+                var editorEx = (EditorEx) editor;
+                editorEx.setViewer(true);
+            }
+        }
     }
 
     private boolean showIfAlreadyOpen(String name, int lineNumber) {

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/UpdateVersionPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/UpdateVersionPanel.kt
@@ -58,14 +58,12 @@ class UpdateVersionPanel(
             val resourceInputStream = UpdateVersionPanel.javaClass.classLoader.getResourceAsStream(resourceName)
             val ioFile = Path.of(tempDirForGuides.absolutePath, resourceName).toFile()
             FileUtil.createParentDirs(ioFile)
-            ioFile.deleteOnExit()
 
             resourceInputStream.use { input ->
                 ioFile.outputStream().use { output ->
                     input.copyTo(output)
                 }
             }
-            ioFile.setWritable(false)
 
             return LocalFileSystem.getInstance().findFileByIoFile(ioFile)!!
         }
@@ -130,11 +128,11 @@ class UpdateVersionPanel(
             if (updateState.shouldUpdateBackend) {
                 when (updateState.backendDeploymentType) {
                     BackendDeploymentType.Helm -> {
-                        EditorService.getInstance(project).openVirtualFile(updateGuideForHelm)
+                        EditorService.getInstance(project).openVirtualFile(updateGuideForHelm, true)
                     }
 
                     BackendDeploymentType.DockerCompose -> {
-                        EditorService.getInstance(project).openVirtualFile(updateGuideDockerCompose)
+                        EditorService.getInstance(project).openVirtualFile(updateGuideDockerCompose, true)
                     }
 
                     BackendDeploymentType.DockerExtension -> {


### PR DESCRIPTION
fixes #627 

the fix : the entire directory has `deleteOnExit = true` - so no need for each file separately.

also added feature that those guides are open in ReadOnly mode.