### PR TITLE
First phase navigation change issue 677

### DIFF
--- a/ide-common/src/main/java/org/digma/intellij/plugin/common/DebugUtilDontCommit.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/common/DebugUtilDontCommit.java
@@ -1,0 +1,13 @@
+package org.digma.intellij.plugin.common;
+
+public class DebugUtilDontCommit {
+
+    //for debugging only. when need to see stack trace but debugging changes everything
+//    public static void printStackTrace(Logger LOGGER) {
+//        Log.log(LOGGER::debug,"Stack trace:");
+//        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+//            Log.log(LOGGER::debug,ste.toString());
+//        }
+//    }
+
+}

--- a/ide-common/src/main/java/org/digma/intellij/plugin/document/DocumentInfoService.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/document/DocumentInfoService.java
@@ -147,8 +147,10 @@ public class DocumentInfoService {
 
         DocumentInfoContainer documentInfoContainer = documents.get(methodInfo.getContainingFileUri());
         if (documentInfoContainer != null) {
+            Log.log(LOGGER::debug, "DocumentInfoContainer exists for MethodInfo {}, getting insights", methodInfo.getId());
             return documentInfoContainer.getInsightsForMethod(methodInfo.getId());
         }
+        Log.log(LOGGER::debug, "DocumentInfoContainer does not exist for MethodInfo {}", methodInfo.getId());
         return Collections.emptyList();
     }
 

--- a/ide-common/src/main/java/org/digma/intellij/plugin/editor/CurrentContextUpdater.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/editor/CurrentContextUpdater.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.NotNull;
  * Processes requests to update the current method context as a result of caret
  * event or document change event.
  */
-class CurrentContextUpdater {
+public class CurrentContextUpdater {
 
     private static final Logger LOGGER = Logger.getInstance(CurrentContextUpdater.class);
     private final Project project;
@@ -38,7 +38,7 @@ class CurrentContextUpdater {
     */
     private MethodUnderCaret latestMethodUnderCaret;
 
-    CurrentContextUpdater(Project project) {
+    public CurrentContextUpdater(Project project) {
         this.project = project;
         caretContextService = project.getService(CaretContextService.class);
         languageServiceLocator = project.getService(LanguageServiceLocator.class);

--- a/ide-common/src/main/java/org/digma/intellij/plugin/editor/EditorEventsHandler.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/editor/EditorEventsHandler.java
@@ -55,7 +55,7 @@ public class EditorEventsHandler implements FileEditorManagerListener {
         caretContextService = project.getService(CaretContextService.class);
         languageServiceLocator = project.getService(LanguageServiceLocator.class);
         documentInfoService = project.getService(DocumentInfoService.class);
-        currentContextUpdater = new CurrentContextUpdater(project);
+        currentContextUpdater = project.getService(CurrentContextUpdater.class);
         caretListener = new CaretListener(project,currentContextUpdater);
         documentChangeListener = new DocumentChangeListener(project,currentContextUpdater);
         contextChangeAlarmAfterFileClosed = AlarmFactory.getInstance().create();

--- a/ide-common/src/main/java/org/digma/intellij/plugin/ui/MainToolWindowCardsController.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/ui/MainToolWindowCardsController.java
@@ -268,16 +268,6 @@ public class MainToolWindowCardsController implements Disposable {
 
 
 
-    //for debugging only.
-    //it's not easy to debug this class with debugger because debugger changes focus behaviour,
-    // it's easier with debug logging and printStackTrace can help to understand who called this class
-//    private void printStackTrace() {
-//        Log.log(LOGGER::debug,"Stack trace:");
-//        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
-//            Log.log(LOGGER::debug,ste.toString());
-//        }
-//    }
-
 
     private static class WizardComponents{
         Content wizardContent;

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/insights/AbstractInsightsProvider.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/insights/AbstractInsightsProvider.kt
@@ -1,0 +1,98 @@
+package org.digma.intellij.plugin.insights
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import org.digma.intellij.plugin.analytics.AnalyticsService
+import org.digma.intellij.plugin.analytics.AnalyticsServiceException
+import org.digma.intellij.plugin.errors.ErrorsListContainer
+import org.digma.intellij.plugin.insights.view.BuildersHolder
+import org.digma.intellij.plugin.insights.view.InsightsViewBuilder
+import org.digma.intellij.plugin.log.Log
+import org.digma.intellij.plugin.model.InsightType
+import org.digma.intellij.plugin.model.discovery.MethodInfo
+import org.digma.intellij.plugin.model.rest.errors.CodeObjectError
+import org.digma.intellij.plugin.model.rest.insights.CodeObjectInsight
+import org.digma.intellij.plugin.model.rest.usage.UsageStatusResult
+import org.digma.intellij.plugin.ui.model.listview.ListViewItem
+
+abstract class AbstractInsightsProvider(val project: Project) {
+
+    private val logger: Logger = Logger.getInstance(javaClass)
+
+    abstract fun getObject():Any
+
+    abstract fun getObjectIdsWithType():List<String>
+
+    //we want to use existing infrastructures for building the list on insights, until more refactoring is done
+    // for the new navigation we need to provide a fake or possible MethodInfo.
+    // InsightsViewBuilder.build need a MethodInfo and expects it to be non-null and with real values.
+    abstract fun getNonNulMethodInfo(): MethodInfo
+
+    fun getInsights(): InsightsListContainer? {
+
+        val analyticsService = AnalyticsService.getInstance(project)
+        val objectIds = getObjectIdsWithType()
+
+        try {
+
+            Log.log(logger::debug,project,"requesting insights for {}",getObject())
+            val insights :List<CodeObjectInsight>  = analyticsService.getInsights(objectIds)
+            Log.log(logger::debug,project,"Got insights for {} [{}]",getObject(),insights)
+
+            Log.log(logger::debug,project,"requesting usageStatus for {}",getObject())
+            val usageStatus:UsageStatusResult = analyticsService.getUsageStatus(objectIds)
+            Log.log(logger::debug,project,"Got usageStatus for {} [{}]",getObject(),usageStatus)
+
+            Log.log(logger::debug,project,"requesting usageStatusOfErrors for {}",getObject())
+            val usageStatusOfErrors:UsageStatusResult = analyticsService.getUsageStatusOfErrors(objectIds)
+            Log.log(logger::debug,project,"Got usageStatusOfErrors for {} [{}]",getObject(),usageStatusOfErrors)
+
+            return getInsightsListContainer(filterUnmapped(insights), usageStatus)
+
+        } catch (e: AnalyticsServiceException) {
+            Log.debugWithException(logger,e, "Cannot load insights for {} Because: {}",getObject() , e.message)
+            return null
+        }
+    }
+
+    private fun getInsightsListContainer(
+        insightsList: List<CodeObjectInsight>,
+        usageStatus: UsageStatusResult,
+    ): InsightsListContainer {
+        val insightsViewBuilder = InsightsViewBuilder(BuildersHolder())
+        val listViewItems = insightsViewBuilder.build(project, getNonNulMethodInfo(), insightsList)
+        Log.log(logger::debug, "ListViewItems for {}: {}", getObject(), listViewItems)
+        return InsightsListContainer(listViewItems, insightsList.size, usageStatus)
+    }
+
+
+    private fun filterUnmapped(codeObjectInsights: List<CodeObjectInsight>): List<CodeObjectInsight> {
+        return codeObjectInsights.filter { it.type != InsightType.Unmapped }
+    }
+
+
+    fun getErrors(): ErrorsListContainer? {
+
+        val analyticsService = AnalyticsService.getInstance(project)
+        val objectIds = getObjectIdsWithType()
+
+        try {
+            Log.log(logger::debug,project,"requesting errors for {}",getObject())
+            val codeObjectErrors: List<CodeObjectError> = analyticsService.getErrorsOfCodeObject(objectIds)
+            Log.log(logger::debug,project,"Got errors for {} [{}]",getObject(),codeObjectErrors)
+
+            val errorsListViewItems = codeObjectErrors.map { ListViewItem(it, 1) }
+            Log.log(logger::debug, "ListViewItems for {}: {}", getObject(), errorsListViewItems)
+
+            val usageStatus = analyticsService.getUsageStatusOfErrors(objectIds)
+            Log.log(logger::debug, "UsageStatus for {}: {}", getObject(), usageStatus)
+
+            return ErrorsListContainer(errorsListViewItems, usageStatus)
+        } catch (e: AnalyticsServiceException){
+            Log.debugWithException(logger,e, "Cannot load errors for {} Because: {}",getObject() , e.message)
+            return null
+        }
+    }
+
+
+}

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/insights/CodeLessSpanInsightsProvider.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/insights/CodeLessSpanInsightsProvider.kt
@@ -1,0 +1,34 @@
+package org.digma.intellij.plugin.insights
+
+import com.intellij.openapi.project.Project
+import org.digma.intellij.plugin.document.CodeObjectsUtil
+import org.digma.intellij.plugin.model.discovery.CodeLessSpan
+import org.digma.intellij.plugin.model.discovery.MethodInfo
+
+class CodeLessSpanInsightsProvider(private val codeLessSpan: CodeLessSpan, project: Project): AbstractInsightsProvider(project) {
+
+
+    override fun getObject(): Any {
+        return codeLessSpan
+    }
+
+
+    override fun getObjectIdsWithType(): List<String> {
+
+        val ids = mutableListOf<String>(CodeObjectsUtil.addSpanTypeToId(codeLessSpan.spanId))
+        if (codeLessSpan.methodId != null){
+            ids.add(CodeObjectsUtil.addMethodTypeToId(codeLessSpan.methodId!!))
+        }
+        return ids
+    }
+
+    override fun getNonNulMethodInfo(): MethodInfo {
+        //this is actually a fake MethodInfo needed by AbstractInsightsProvider to call insightsViewBuilder.build.
+        // this info arrived from jaeger ui,  if methodId is real then maybe it will help insightsViewBuilder.build find code locations
+        // and if not it will probably do nothing with it as nothing will be found.
+        return MethodInfo(codeLessSpan.methodId.toString(),codeLessSpan.functionName.toString(),"",codeLessSpan.functionNamespace.toString(),"",0,listOf())
+    }
+
+
+
+}

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/ui/service/SummaryViewService.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/ui/service/SummaryViewService.kt
@@ -128,6 +128,8 @@ class SummaryViewService(project: Project) : AbstractViewService(project) {
 
         override fun isDocumentScope(): Boolean = false
 
+        override fun isCodeLessSpanScope(): Boolean = false
+
         override fun getScope(): String = "Current environment"
 
         override fun getScopeTooltip(): String = ""

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/discovery/CodeLessSpan.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/discovery/CodeLessSpan.kt
@@ -1,0 +1,10 @@
+package org.digma.intellij.plugin.model.discovery
+
+data class CodeLessSpan(
+    val spanId: String,
+    val spanInstLibrary: String,
+    val spanName: String,
+    val methodId: String?,
+    val functionNamespace: String?,
+    val functionName: String?
+)

--- a/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/PanelModel.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/PanelModel.kt
@@ -10,6 +10,8 @@ interface PanelModel {
 
     fun isDocumentScope(): Boolean
 
+    fun isCodeLessSpanScope(): Boolean
+
     fun getScope(): String
 
     fun getScopeTooltip(): String

--- a/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/Scopes.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/Scopes.kt
@@ -1,5 +1,6 @@
 package org.digma.intellij.plugin.ui.model
 
+import org.digma.intellij.plugin.model.discovery.CodeLessSpan
 import org.digma.intellij.plugin.model.discovery.DocumentInfo
 import org.digma.intellij.plugin.model.discovery.MethodInfo
 
@@ -40,6 +41,20 @@ class MethodScope(private val methodInfo: MethodInfo) : Scope {
         return methodInfo
     }
 }
+
+
+class CodeLessSpanScope(private val codeLessSpan: CodeLessSpan) : Scope {
+    override fun getScope(): String {
+        return codeLessSpan.spanId
+    }
+
+    override fun getScopeTooltip(): String {
+        return codeLessSpan.spanId
+    }
+
+}
+
+
 
 class DocumentScope(private val documentInfo: DocumentInfo) : Scope {
     override fun getScope(): String {

--- a/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/Scopes.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/Scopes.kt
@@ -45,11 +45,11 @@ class MethodScope(private val methodInfo: MethodInfo) : Scope {
 
 class CodeLessSpanScope(private val codeLessSpan: CodeLessSpan) : Scope {
     override fun getScope(): String {
-        return codeLessSpan.spanId
+        return codeLessSpan.spanName
     }
 
     override fun getScopeTooltip(): String {
-        return codeLessSpan.spanId
+        return codeLessSpan.spanName
     }
 
 }

--- a/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/errors/ErrorsModel.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/errors/ErrorsModel.kt
@@ -3,6 +3,7 @@ package org.digma.intellij.plugin.ui.model.errors
 import org.digma.intellij.plugin.model.Models.Empties.EmptyUsageStatusResult
 import org.digma.intellij.plugin.model.rest.errors.CodeObjectError
 import org.digma.intellij.plugin.model.rest.usage.UsageStatusResult
+import org.digma.intellij.plugin.ui.model.CodeLessSpanScope
 import org.digma.intellij.plugin.ui.model.DocumentScope
 import org.digma.intellij.plugin.ui.model.EmptyScope
 import org.digma.intellij.plugin.ui.model.MethodScope
@@ -58,6 +59,10 @@ class ErrorsModel : PanelModel {
 
     override fun isDocumentScope(): Boolean {
         return scope is DocumentScope
+    }
+
+    override fun isCodeLessSpanScope(): Boolean {
+        return scope is CodeLessSpanScope
     }
 
     override fun getScope(): String {

--- a/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/insights/InsightsModel.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/insights/InsightsModel.kt
@@ -2,6 +2,7 @@ package org.digma.intellij.plugin.ui.model.insights
 
 import org.digma.intellij.plugin.model.Models.Empties.EmptyUsageStatusResult
 import org.digma.intellij.plugin.model.rest.usage.UsageStatusResult
+import org.digma.intellij.plugin.ui.model.CodeLessSpanScope
 import org.digma.intellij.plugin.ui.model.DocumentScope
 import org.digma.intellij.plugin.ui.model.EmptyScope
 import org.digma.intellij.plugin.ui.model.MethodScope
@@ -55,6 +56,10 @@ class InsightsModel : PanelModel {
 
     override fun isDocumentScope(): Boolean {
         return scope is DocumentScope
+    }
+
+    override fun isCodeLessSpanScope(): Boolean {
+        return scope is CodeLessSpanScope
     }
 
     override fun getScope(): String {

--- a/src/main/java/org/digma/intellij/plugin/jaegerui/JaegerUIService.java
+++ b/src/main/java/org/digma/intellij/plugin/jaegerui/JaegerUIService.java
@@ -40,6 +40,7 @@ import static org.digma.intellij.plugin.document.CodeObjectsUtil.addMethodTypeTo
 import static org.digma.intellij.plugin.document.CodeObjectsUtil.addSpanTypeToIds;
 import static org.digma.intellij.plugin.document.CodeObjectsUtil.createMethodCodeObjectId;
 import static org.digma.intellij.plugin.document.CodeObjectsUtil.createSpanId;
+import static org.digma.intellij.plugin.navigation.codeless.CodelessNavigationKt.navigate;
 
 public class JaegerUIService {
 
@@ -224,6 +225,7 @@ public class JaegerUIService {
                     Pair<String, Integer> location = spanWorkspaceUris.get(spanId);
                     EditorService editorService = project.getService(EditorService.class);
                     EDT.ensureEDT(() -> editorService.openWorkspaceFileInEditor(location.getFirst(), location.getSecond()));
+                    //if code location was found link to it and return.no need to check the other language services
                     return;
                 }else if (span.function() != null && span.namespace() != null){
                     var methodId = createMethodCodeObjectId(span.namespace(),span.function());
@@ -233,11 +235,17 @@ public class JaegerUIService {
                         Pair<String, Integer> location = methodWorkspaceUris.get(methodId);
                         EditorService editorService = project.getService(EditorService.class);
                         EDT.ensureEDT(() -> editorService.openWorkspaceFileInEditor(location.getFirst(), location.getSecond()));
+                        //if code location was found link to it and return.no need to check the other language services
                         return;
                     }
                 }
             }
         }
+
+
+        //if we're here then code location was not found
+        navigate(project,span.instrumentationLibrary(),span.name(),span.namespace(),span.function());
+
     }
 
     public Map<String, SpanData> getResolvedSpans(SpansMessage spansMessage) {

--- a/src/main/java/org/digma/intellij/plugin/service/ErrorsActionsService.java
+++ b/src/main/java/org/digma/intellij/plugin/service/ErrorsActionsService.java
@@ -3,6 +3,7 @@ package org.digma.intellij.plugin.service;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.content.ContentManagerEvent;
 import com.intellij.ui.content.ContentManagerListener;
+import org.digma.intellij.plugin.errors.ErrorsProvider;
 import org.digma.intellij.plugin.model.rest.errors.CodeObjectError;
 import org.digma.intellij.plugin.model.rest.insights.ErrorInsightNamedError;
 import org.digma.intellij.plugin.ui.service.ErrorsViewService;
@@ -44,7 +45,8 @@ public class ErrorsActionsService implements ContentManagerListener {
     public void showErrorDetails(@NotNull String uid) {
         tabsHelper.showingErrorDetails();
         errorsViewService.setVisible();
-        errorsViewService.showErrorDetails(uid);
+        ErrorsProvider errorsProvider  = project.getService(ErrorsProvider.class);
+        errorsViewService.showErrorDetails(uid,errorsProvider);
         tabsHelper.errorDetailsOn();
     }
 

--- a/src/main/java/org/digma/intellij/plugin/toolwindow/recentactivity/DigmaBottomToolWindowFactory.java
+++ b/src/main/java/org/digma/intellij/plugin/toolwindow/recentactivity/DigmaBottomToolWindowFactory.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import static org.digma.intellij.plugin.navigation.codeless.CodelessNavigationKt.navigate;
 import static org.digma.intellij.plugin.toolwindow.common.ToolWindowUtil.GLOBAL_SET_IS_JAEGER_ENABLED;
 import static org.digma.intellij.plugin.toolwindow.common.ToolWindowUtil.RECENT_ACTIVITY_GO_TO_SPAN;
 import static org.digma.intellij.plugin.toolwindow.common.ToolWindowUtil.RECENT_ACTIVITY_GO_TO_TRACE;
@@ -221,6 +222,7 @@ public class DigmaBottomToolWindowFactory implements ToolWindowFactory, Disposab
                 final Pair<String, Integer> fileAndOffset = workspaceUrisForMethodCodeObjectIds.get(methodCodeObjectId);
                 if (fileAndOffset == null) {
                     NotificationUtil.showNotification(project, "code object could not be found in the workspace");
+                    navigate(project,payload.getSpan().getSpanCodeObjectId(),payload.getSpan().getMethodCodeObjectId());
                     return;
                 }
 

--- a/src/main/kotlin/org/digma/intellij/plugin/navigation/codeless/CodelessNavigation.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/navigation/codeless/CodelessNavigation.kt
@@ -4,15 +4,18 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import org.digma.intellij.plugin.document.CodeObjectsUtil
+import org.digma.intellij.plugin.editor.CurrentContextUpdater
 import org.digma.intellij.plugin.log.Log
 import org.digma.intellij.plugin.model.discovery.CodeLessSpan
+import org.digma.intellij.plugin.service.ErrorsActionsService
 import org.digma.intellij.plugin.ui.service.ErrorsViewService
 import org.digma.intellij.plugin.ui.service.InsightsViewService
 
 
 private val logger = Logger.getInstance("org.digma.intellij.plugin.navigation.codeless.CodelessNavigation")
 
-fun navigate(project: Project, spanInstLibrary: String?,
+fun navigate(
+    project: Project, spanInstLibrary: String?,
     spanName: String?, functionNamespace: String?, functionName: String?,
 ) {
 
@@ -46,6 +49,11 @@ fun navigate(project: Project, spanInstLibrary: String?,
         functionNamespace,
         functionName
     ))
+
+    project.service<ErrorsActionsService>().closeErrorDetailsBackButton()
+
+    //clear the latest method so that if user clicks on the editor again after watching code less insights the context will change
+    project.service<CurrentContextUpdater>().clearLatestMethod()
 }
 
 
@@ -71,5 +79,11 @@ fun navigate(project: Project, spanCodeObjectId: String, methodCodeObjectId: Str
         funcNamespace,
         funcName
     ))
+
+
+    project.service<ErrorsActionsService>().closeErrorDetailsBackButton()
+
+    //clear the latest method so that if user clicks on the editor again after watching code less insights the context will change
+    project.service<CurrentContextUpdater>().clearLatestMethod()
 
 }

--- a/src/main/kotlin/org/digma/intellij/plugin/navigation/codeless/CodelessNavigation.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/navigation/codeless/CodelessNavigation.kt
@@ -1,0 +1,75 @@
+package org.digma.intellij.plugin.navigation.codeless
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import org.digma.intellij.plugin.document.CodeObjectsUtil
+import org.digma.intellij.plugin.log.Log
+import org.digma.intellij.plugin.model.discovery.CodeLessSpan
+import org.digma.intellij.plugin.ui.service.ErrorsViewService
+import org.digma.intellij.plugin.ui.service.InsightsViewService
+
+
+private val logger = Logger.getInstance("org.digma.intellij.plugin.navigation.codeless.CodelessNavigation")
+
+fun navigate(project: Project, spanInstLibrary: String?,
+    spanName: String?, functionNamespace: String?, functionName: String?,
+) {
+
+    Log.log(logger::debug,project,"Got navigation request for {} {} {} {}", spanInstLibrary, spanName, functionNamespace, functionName)
+
+
+    if (spanInstLibrary == null || spanName == null) {
+        Log.log(logger::debug,project, "Not navigating because span instrumentation library or span name is null")
+        return
+    }
+
+    val spanId = CodeObjectsUtil.createSpanId(spanInstLibrary, spanName)
+    val methodId = if (functionNamespace != null && functionName != null) CodeObjectsUtil.createMethodCodeObjectId(
+        functionNamespace,functionName) else null
+
+
+    project.service<InsightsViewService>().updateInsightsModel(CodeLessSpan(
+        spanId,
+        spanInstLibrary,
+        spanName,
+        methodId,
+        functionNamespace,
+        functionName
+    ))
+
+    project.service<ErrorsViewService>().updateErrorsModel(CodeLessSpan(
+        spanId,
+        spanInstLibrary,
+        spanName,
+        methodId,
+        functionNamespace,
+        functionName
+    ))
+}
+
+
+fun navigate(project: Project, spanCodeObjectId: String, methodCodeObjectId: String?) {
+    val instLibrary = spanCodeObjectId.substringBefore("\$_$")
+    val spanName = spanCodeObjectId.substringAfter("\$_$")
+    val funcNamespace = methodCodeObjectId?.substringBefore("\$_$")
+    val funcName = methodCodeObjectId?.substringAfter("\$_$")
+    project.service<InsightsViewService>().updateInsightsModel(CodeLessSpan(
+        spanCodeObjectId,
+        instLibrary,
+        spanName,
+        methodCodeObjectId,
+        funcNamespace,
+        funcName
+    ))
+
+    project.service<ErrorsViewService>().updateErrorsModel(CodeLessSpan(
+        spanCodeObjectId,
+        instLibrary,
+        spanName,
+        methodCodeObjectId,
+        funcNamespace,
+        funcName
+    ))
+
+}

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/InstallationWizardSidePanelWindowPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/InstallationWizardSidePanelWindowPanel.kt
@@ -169,6 +169,8 @@ fun createInstallationWizardSidePanelWindowPanel(project: Project): DisposablePa
     val jcefDigmaPanel = object: DisposablePanel(){
         override fun dispose() {
             jbCefBrowser.dispose()
+            jbCefClient.dispose()
+            msgRouter.dispose()
         }
     }
     jcefDigmaPanel.layout = BorderLayout()

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/ScopeLineIconProducer.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/ScopeLineIconProducer.kt
@@ -12,6 +12,8 @@ class ScopeLineIconProducer(val model: PanelModel): Producer<Icon> {
             return Laf.Icons.Insight.METHOD
         }else if (model.isDocumentScope()){
             return Laf.Icons.Insight.FILE
+        }else if (model.isCodeLessSpanScope()){
+            return Laf.Icons.Insight.TELESCOPE
         }
         return Laf.Icons.Insight.EMPTY
     }

--- a/src/main/resources/META-INF/org.digma.intellij-with-intellij-platform.xml
+++ b/src/main/resources/META-INF/org.digma.intellij-with-intellij-platform.xml
@@ -1,14 +1,14 @@
 <idea-plugin>
 
     <!--
-       This file is meant to declare services and extension points that are common to all IDEs that
-       are not Rider.
-       these are services that are necessary only for language plugins that are implemented fully with intellij platform
-       and run only on the JVM.
-       the reason is it declares services and listeners that are not necessary in Rider.
-       although they will load in Rider but usually do nothing.
-       for example EditorEventsHandler will load in Rider but will ignore C# files.
+    This file was a separate file when CSharpLanguageService language service was async to rider backend.
+    but we changed CSharpLanguageService to work sync like the other language services and this file
+    is nit really necessary and the declarations can move to the main plugin file.
        -->
+
+    <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="org.digma.intellij.plugin.editor.CurrentContextUpdater"/>
+    </extensions>
 
     <projectListeners>
         <listener

--- a/src/main/resources/webview/jaegerui/index.html
+++ b/src/main/resources/webview/jaegerui/index.html
@@ -45,7 +45,7 @@
       window.isUserDefinedJaegerQueryURL;
       window.staticPath;
     </script>
-    <script type="module" crossorigin src="./static/index-ddbfb09b.js"></script>
+    <script type="module" crossorigin src="./static/index-ae025a3a.js"></script>
     <link rel="stylesheet" href="./static/index-7d3da107.css">
     <script type="module">import.meta.url;import("_").catch(()=>1);async function* g(){};window.__vite_is_modern_browser=true;</script>
     <script type="module">!function(){if(window.__vite_is_modern_browser)return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("vite-legacy-polyfill"),n=document.createElement("script");n.src=e.src,n.onload=function(){System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))},document.body.appendChild(n)}();</script>
@@ -60,6 +60,6 @@
     
     <script nomodule>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",(function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()}),!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
     <script nomodule crossorigin id="vite-legacy-polyfill" src="./static/polyfills-legacy-9486af1f.js"></script>
-    <script nomodule crossorigin id="vite-legacy-entry" data-src="./static/index-legacy-b7ae23aa.js">System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))</script>
+    <script nomodule crossorigin id="vite-legacy-entry" data-src="./static/index-legacy-eba3947d.js">System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))</script>
   </body>
 </html>

--- a/src/main/resources/webview/jaegerui/jaegeruitemplate.ftl
+++ b/src/main/resources/webview/jaegerui/jaegeruitemplate.ftl
@@ -43,10 +43,10 @@
       window.apiBaseUrl = "${jaeger_url}";
       window.initialRoutePath = "${initial_route}";
       window.embeddedMode = true;
-      window.staticPath;
       window.isUserDefinedJaegerQueryURL = ${isUserChangedJaegerQueryUrl};
+      window.staticPath;
     </script>
-    <script type="module" crossorigin src="./static/index-ddbfb09b.js"></script>
+    <script type="module" crossorigin src="./static/index-ae025a3a.js"></script>
     <link rel="stylesheet" href="./static/index-7d3da107.css">
     <script type="module">import.meta.url;import("_").catch(()=>1);async function* g(){};window.__vite_is_modern_browser=true;</script>
     <script type="module">!function(){if(window.__vite_is_modern_browser)return;console.warn("vite: loading legacy chunks, syntax error above and the same error below should be ignored");var e=document.getElementById("vite-legacy-polyfill"),n=document.createElement("script");n.src=e.src,n.onload=function(){System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))},document.body.appendChild(n)}();</script>
@@ -61,6 +61,6 @@
 
     <script nomodule>!function(){var e=document,t=e.createElement("script");if(!("noModule"in t)&&"onbeforeload"in t){var n=!1;e.addEventListener("beforeload",(function(e){if(e.target===t)n=!0;else if(!e.target.hasAttribute("nomodule")||!n)return;e.preventDefault()}),!0),t.type="module",t.src=".",e.head.appendChild(t),t.remove()}}();</script>
     <script nomodule crossorigin id="vite-legacy-polyfill" src="./static/polyfills-legacy-9486af1f.js"></script>
-    <script nomodule crossorigin id="vite-legacy-entry" data-src="./static/index-legacy-b7ae23aa.js">System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))</script>
+    <script nomodule crossorigin id="vite-legacy-entry" data-src="./static/index-legacy-eba3947d.js">System.import(document.getElementById('vite-legacy-entry').getAttribute('data-src'))</script>
   </body>
 </html>


### PR DESCRIPTION
first phase navigation , show insights for non-discoverable span. supports a request for go-to-span from jaeger ui and recent activity.

currently there is no refresh for the insights.

there is one issue:
if the cursor is inside a method body and the insights are shown in the insights window. click a non discoverable span in recent activity, the insights for the span are shown. when click the method again  the view is not replaced until you click somewhere outside the latest method. how do we want that to behave? replace the view again on first click in the method?


[Screencast from 2023-05-21 22-59-04.webm](https://github.com/digma-ai/digma-intellij-plugin/assets/170266/be31ad4d-c630-440a-92eb-1dd980b8f6ee)

