### PR TITLE
Bugfix/CodeLens uniqueness - add codeObjectId

### DIFF
--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/lens/CodeLens.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/lens/CodeLens.kt
@@ -10,17 +10,19 @@ data class CodeLens(
     var lensMoreText: String = ""
     var anchor: String = ""
 
-    // generated code. hashCode and equals on top of lensTitle, in order to avoid duplicates
+    // generated code. hashCode and equals on top of codeObjectId and lensTitle, in order to avoid duplicates
     override fun hashCode(): Int {
-        return lensTitle.hashCode()
+        var result = codeObjectId.hashCode()
+        result = 31 * result + lensTitle.hashCode()
+        return result
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is CodeLens) return false
 
+        if (codeObjectId != other.codeObjectId) return false
         return lensTitle == other.lensTitle
     }
-
 
 }


### PR DESCRIPTION
fixes #725 

add codeObjectId to equals and hashCode
