### PR TITLE
fix error details name label not showing

### DIFF
--- a/src/main/kotlin/org/digma/intellij/plugin/ui/common/CopyableLabel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/common/CopyableLabel.kt
@@ -7,13 +7,15 @@ import java.awt.Font
 import java.awt.Rectangle
 import javax.swing.JTextPane
 
+//todo: JBLabel could be a better alternative with setCopyable(true) and isAllowAutoWrapping = true,
+// but i couldn't make tooltip work with JBLabel
+
 open class BaseCopyableLabel(val myText: String) : JTextPane() {
 
     protected fun construct(myText: String, foregroundColor: Color) {
         isEditable = false
         isOpaque = false
         background = null
-        border = null
         putClientProperty(HONOR_DISPLAY_PROPERTIES, true)
         font = DEFAULT_FONT
         text = myText

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/errors/ErrorDetailsPanel.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/errors/ErrorDetailsPanel.kt
@@ -3,7 +3,11 @@ package org.digma.intellij.plugin.ui.errors
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.JBColor
-import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.dsl.builder.MutableProperty
+import com.intellij.ui.dsl.builder.RightGap
+import com.intellij.ui.dsl.builder.RowLayout
+import com.intellij.ui.dsl.builder.TopGap
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import com.intellij.ui.dsl.gridLayout.VerticalAlign
 import com.intellij.util.ui.JBUI.Borders
@@ -14,14 +18,28 @@ import org.digma.intellij.plugin.model.rest.errors.CodeObjectError
 import org.digma.intellij.plugin.persistence.PersistenceService
 import org.digma.intellij.plugin.posthog.ActivityMonitor
 import org.digma.intellij.plugin.service.ErrorsActionsService
-import org.digma.intellij.plugin.ui.common.*
+import org.digma.intellij.plugin.ui.common.CopyableLabel
+import org.digma.intellij.plugin.ui.common.CopyableLabelHtml
+import org.digma.intellij.plugin.ui.common.JTransparentPanel
+import org.digma.intellij.plugin.ui.common.Laf
+import org.digma.intellij.plugin.ui.common.asHtml
+import org.digma.intellij.plugin.ui.common.boldFonts
+import org.digma.intellij.plugin.ui.common.buildBoldGrayRegularText
+import org.digma.intellij.plugin.ui.common.createScorePanelNoArrows
+import org.digma.intellij.plugin.ui.common.span
+import org.digma.intellij.plugin.ui.common.spanGrayed
 import org.digma.intellij.plugin.ui.list.ScrollablePanelList
 import org.digma.intellij.plugin.ui.list.errordetails.ErrorFramesPanelList
 import org.digma.intellij.plugin.ui.list.listBackground
 import org.digma.intellij.plugin.ui.model.errors.ErrorsModel
 import org.digma.intellij.plugin.ui.panels.DigmaTabPanel
-import java.awt.*
-import java.util.*
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.GridLayout
+import java.util.Date
 import java.util.function.Consumer
 import javax.swing.JComponent
 import javax.swing.JLabel
@@ -439,7 +457,7 @@ private fun namePanel(errorsModel: ErrorsModel): DialogPanel {
 
             }
         }
-    }.andTransparent().withBorder(Borders.customLine(Color.DARK_GRAY, 0, 2, 0, 0))
+    }.andTransparent().withBorder(Borders.customLine(JBColor.DARK_GRAY, 0, 2, 0, 0))
 
 }
 


### PR DESCRIPTION
This is voodo, i don't understand why it started happening , nothing changed in copyable label but suddenly the error details name is not showing. when i remove border=null from copyable label its ok again. I have no idea why, it works for the past year and suddenly not. other places using CopyableLabel work with no issues.
an alternative to CopyableLabel can be JBLabel with setCopyable(true) and isAllowAutoWrapping = true , but for some reason tooltip is not working in JBLabel.