### PR TITLE
Cleanup obsolete props in `SlowEndpointInsight`

### DIFF
--- a/analytics-provider/src/test/java/org/digma/intellij/plugin/analytics/InsightsTests.java
+++ b/analytics-provider/src/test/java/org/digma/intellij/plugin/analytics/InsightsTests.java
@@ -189,15 +189,8 @@ class InsightsTests extends AbstractAnalyticsProviderTest {
                 , SERVICE
                 , new Duration(0.11D, "ms", 11000)
                 , new Duration(0.12D, "ms", 12000)
-                , new Duration(0.13D, "ms", 13000)
                 , new Duration(0.14D, "ms", 14000)
-                , new Duration(0.15D, "ms", 15000)
-                , new Duration(0.16D, "ms", 16000)
-                , new Duration(0.17D, "ms", 17000)
                 , new Duration(0.18D, "ms", 18000)
-                , new Duration(0.19D, "ms", 19000)
-                , new Duration(0.21D, "ms", 21000)
-                , new Duration(0.22D, "ms", 22000)
         );
         expectedCodeObjectInsights.add(expectedSlowEndpointInsight);
 
@@ -358,15 +351,8 @@ class InsightsTests extends AbstractAnalyticsProviderTest {
                 , SERVICE
                 , new Duration(0.11D, "ms", 11000)
                 , new Duration(0.12D, "ms", 12000)
-                , new Duration(0.13D, "ms", 13000)
                 , new Duration(0.14D, "ms", 14000)
-                , new Duration(0.15D, "ms", 15000)
-                , new Duration(0.16D, "ms", 16000)
-                , new Duration(0.17D, "ms", 17000)
                 , new Duration(0.18D, "ms", 18000)
-                , new Duration(0.19D, "ms", 19000)
-                , new Duration(0.21D, "ms", 21000)
-                , new Duration(0.22D, "ms", 22000)
         );
         expectedCodeObjectInsights.add(expectedSlowEndpointInsight);
 

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SlowEndpointInsight.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SlowEndpointInsight.kt
@@ -25,15 +25,8 @@ data class SlowEndpointInsight
         "serviceName",
         "endpointsMedian",
         "endpointsMedianOfMedians",
-        "endpointsMedianOfP75",
         "endpointsP75",
-        "min",
-        "max",
-        "mean",
         "median",
-        "p75",
-        "p95",
-        "p99",
 )
 constructor(
         override val codeObjectId: String,
@@ -51,15 +44,8 @@ constructor(
         override var serviceName: String,
         val endpointsMedian: Duration,
         val endpointsMedianOfMedians: Duration,
-        val endpointsMedianOfP75: Duration,
         val endpointsP75: Duration,
-        val min: Duration,
-        val max: Duration,
-        val mean: Duration,
         val median: Duration,
-        val p75: Duration,
-        val p95: Duration,
-        val p99: Duration,
 ) : EndpointInsight {
     override val type: InsightType = InsightType.SlowEndpoint
 }


### PR DESCRIPTION
Part of https://github.com/digma-ai/digma-collector-backend/issues/970