### PR TITLE
Fix environment refresh

### DIFF
--- a/ide-common/src/main/java/org/digma/intellij/plugin/analytics/AnalyticsService.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/analytics/AnalyticsService.java
@@ -61,7 +61,6 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.net.http.HttpTimeoutException;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -112,7 +111,7 @@ public class AnalyticsService implements Disposable {
         //initialize MainToolWindowCardsController when starting, so it is aware early on connection statuses
         MainToolWindowCardsController.getInstance(project);
         SettingsState settingsState = SettingsState.getInstance();
-        environment = new Environment(project, this, PersistenceService.getInstance().getState(), settingsState);
+        environment = new Environment(project, this, PersistenceService.getInstance().getState());
         this.project = project;
         myApiUrl = settingsState.apiUrl;
         myApiToken = settingsState.apiToken;
@@ -160,12 +159,7 @@ public class AnalyticsService implements Disposable {
 
 
     private void initializeEnvironmentsList() {
-        List<String> envs = getEnvironments();
-        if (envs == null) {
-            envs = new ArrayList<>();
-        }
-
-        environment.replaceEnvironmentsList(envs);
+        environment.refreshNowOnBackground();
     }
 
 
@@ -173,12 +167,7 @@ public class AnalyticsService implements Disposable {
 
         Backgroundable.ensureBackground(project, "Digma: Environments list changed", () -> {
             replaceClient(url, token);
-            List<String> envs = getEnvironments();
-            if (envs == null) {
-                envs = new ArrayList<>();
-            }
-
-            environment.replaceEnvironmentsListAndFireChange(envs);
+            environment.refreshNowOnBackground();
         });
 
     }

--- a/ide-common/src/main/java/org/digma/intellij/plugin/analytics/Environment.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/analytics/Environment.java
@@ -41,7 +41,7 @@ public class Environment implements EnvironmentsSupplier {
         this.analyticsService = analyticsService;
         this.persistenceData = persistenceData;
         this.current = persistenceData.getCurrentEnv();
-        scheduleEnvironmentRefresh(project, analyticsService, this);
+        scheduleEnvironmentRefresh(analyticsService, this);
 
         //call refresh on environment when connection is lost, in some cases its necessary for some components to reset or update ui.
         //usually these components react to environment change events, so this will trigger an environment change if not already happened before.

--- a/ide-common/src/main/java/org/digma/intellij/plugin/analytics/Environment.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/analytics/Environment.java
@@ -7,13 +7,10 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.digma.intellij.plugin.common.Backgroundable;
 import org.digma.intellij.plugin.log.Log;
 import org.digma.intellij.plugin.persistence.PersistenceData;
-import org.digma.intellij.plugin.settings.SettingsState;
 import org.digma.intellij.plugin.ui.model.environment.EnvironmentsSupplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -21,13 +18,14 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.digma.intellij.plugin.analytics.EnvironmentRefreshSchedulerKt.scheduleEnvironmentRefresh;
+
 public class Environment implements EnvironmentsSupplier {
 
     private static final Logger LOGGER = Logger.getInstance(Environment.class);
     private static final String NO_ENVIRONMENTS_MESSAGE = "No Environments";
 
     private String current;
-    private final SettingsState settingsState;
 
     @NotNull
     private List<String> environments = new ArrayList<>();
@@ -36,16 +34,14 @@ public class Environment implements EnvironmentsSupplier {
     private final AnalyticsService analyticsService;
     private final PersistenceData persistenceData;
 
-    private Instant lastRefreshTimestamp = Instant.now();
-
     private final ReentrantLock envChangeLock = new ReentrantLock();
 
-    public Environment(@NotNull Project project, @NotNull AnalyticsService analyticsService, @NotNull PersistenceData persistenceData, SettingsState settingsState) {
+    public Environment(@NotNull Project project, @NotNull AnalyticsService analyticsService, @NotNull PersistenceData persistenceData) {
         this.project = project;
         this.analyticsService = analyticsService;
         this.persistenceData = persistenceData;
         this.current = persistenceData.getCurrentEnv();
-        this.settingsState = settingsState;
+        scheduleEnvironmentRefresh(project, analyticsService, this);
 
         //call refresh on environment when connection is lost, in some cases its necessary for some components to reset or update ui.
         //usually these components react to environment change events, so this will trigger an environment change if not already happened before.
@@ -53,18 +49,15 @@ public class Environment implements EnvironmentsSupplier {
         project.getMessageBus().connect(analyticsService).subscribe(AnalyticsServiceConnectionEvent.ANALYTICS_SERVICE_CONNECTION_EVENT_TOPIC, new AnalyticsServiceConnectionEvent() {
             @Override
             public void connectionLost() {
-                refresh();
+                refreshNowOnBackground();
             }
 
             @Override
             public void connectionGained() {
-                if (getCurrent() == null || getCurrent().isEmpty()) {
-                    refreshNowOnBackground();
-                }
+                refreshNowOnBackground();
             }
         });
     }
-
 
 
     @Override
@@ -73,73 +66,52 @@ public class Environment implements EnvironmentsSupplier {
     }
 
     @Override
-    public void setCurrent(@NotNull String newEnv) {
-        setCurrent(newEnv,true,false,null);
+    public void setCurrent(@Nullable String newEnv) {
+
+        if (StringUtils.isEmpty(newEnv) || NO_ENVIRONMENTS_MESSAGE.equals(newEnv)) {
+            return;
+        }
+
+        setCurrent(newEnv, true, null);
     }
 
-    @Override
-    public void setCurrent(@NotNull String newEnv,boolean forceChange) {
-        setCurrent(newEnv,true,forceChange,null);
-    }
 
+    //this method does not handle illegal or null environment. it should be called with a non-null newEnv
+    // that exists in the DB.
     @Override
-    public void setCurrent(@Nullable String newEnv,boolean refreshInsightsView,@Nullable Runnable taskToRunAfterChange){
-        setCurrent(newEnv,refreshInsightsView,false,taskToRunAfterChange);
-    }
-
-    @Override
-    public void setCurrent(@Nullable String newEnv,boolean refreshInsightsView,boolean forceChange,@Nullable Runnable taskToRunAfterChange){
+    public void setCurrent(@NotNull String newEnv, boolean refreshInsightsView, @Nullable Runnable taskToRunAfterChange) {
 
         Log.log(LOGGER::debug, "Setting current environment , old={},new={}", this.current, newEnv);
 
-        //check if value is illegal
-        if (StringUtils.isEmpty(newEnv) || NO_ENVIRONMENTS_MESSAGE.equals(newEnv)){
+        if (StringUtils.isEmpty(newEnv)) {
+            Log.log(LOGGER::debug, "setCurrent was called with an empty environment {}", newEnv);
             return;
         }
 
-        //don't change or fire the event if it's the same env. unless forceChange is true
-        if (!forceChange && Objects.equals(this.current, newEnv)) {
-
-            //run the task even if no need to change environment
-            if (taskToRunAfterChange != null){
-                taskToRunAfterChange.run();
-            }
-
-            return;
-        }
-
-
-        //changeEnvironment must run in the background, the use of envChangeLock makes sure no two threads
-        //change environment at the same time. if user changes environments very quickly they will run one after the
-        // other.
-        //listeners that handle environmentChanged event in most cases need to stay on the same thread.
+        //this setCurrent method is called from RecentActivityService, it may send an env that does not exist in  the
+        // list of environments. so refresh if necessary.
         Runnable task = () -> {
             envChangeLock.lock();
             try {
+                //run both refreshEnvironments and updateCurrentEnv under same lock
                 if (environments.isEmpty() || !environments.contains(newEnv)) {
-                    // we got here to changeEnv but list is empty, probably first run/call
                     refreshEnvironments();
                 }
-                changeEnvironment(newEnv,refreshInsightsView,taskToRunAfterChange);
+                updateCurrentEnv(newEnv, refreshInsightsView);
             } finally {
-                envChangeLock.unlock();
+                if (envChangeLock.isHeldByCurrentThread()) {
+                    envChangeLock.unlock();
+                }
             }
+
+            //runs in background but not under lock
+            if (taskToRunAfterChange != null) {
+                taskToRunAfterChange.run();
+            }
+
         };
 
         Backgroundable.ensureBackground(project, "Digma: environment changed " + newEnv, task);
-    }
-
-
-    private void changeEnvironment(@NotNull String newEnv,boolean refreshInsightsView,@Nullable Runnable taskToRunAfterChange) {
-        if (StringUtils.isNotEmpty(newEnv)) {
-            var oldEnv = this.current;
-            this.current = newEnv;
-            persistenceData.setCurrentEnv(newEnv);
-            if (taskToRunAfterChange != null){
-                taskToRunAfterChange.run();
-            }
-            notifyEnvironmentChanged(oldEnv, newEnv,refreshInsightsView);
-        }
     }
 
 
@@ -150,55 +122,31 @@ public class Environment implements EnvironmentsSupplier {
     }
 
 
-    //refresh is called many times, every time the method context changes,and it's not necessary to
-    //really try every time,its used as a hook to refresh in case the backend list changed.
-    //so it will only refresh if some time passed since the last call
-    @Override
-    public void refresh() {
-        refreshOnlyEverySomeTimePassed();
-    }
-
-
-    //this should be used when a refresh is necessary as soon as possible.
     @Override
     public void refreshNowOnBackground() {
-        refreshOnBackground();
-    }
 
-    private void refreshOnlyEverySomeTimePassed() {
-
-        if (!timeToRefresh()) {
-            Log.log(LOGGER::debug, "Skipping Refresh Environments , will try again in few seconds..");
-            return;
-        }
-
-        refreshOnBackground();
-    }
-
-
-    private void refreshOnBackground() {
         Log.log(LOGGER::debug, "Refreshing Environments on background thread.");
-        Backgroundable.ensureBackground(project, "Refreshing Environments on background thread.", this::refreshEnvironments);
+        Backgroundable.ensureBackground(project, "Refreshing Environments", () -> {
+            envChangeLock.lock();
+            try {
+                //run both refreshEnvironments and updateCurrentEnv under same lock
+                refreshEnvironments();
+                updateCurrentEnv(persistenceData.getCurrentEnv(), true);
+            } finally {
+                if (envChangeLock.isHeldByCurrentThread()) {
+                    envChangeLock.unlock();
+                }
+            }
+        });
     }
-
-
-    private boolean timeToRefresh() {
-        //don't try to refresh to often, It's usually not necessary
-        var now = Instant.now();
-        Duration duration = Duration.between(lastRefreshTimestamp, now);
-        if (duration.getSeconds() < settingsState.refreshDelay){
-            return false;
-        }
-        lastRefreshTimestamp = now;
-        return true;
-    }
-
 
 
     //this method should not be called on ui threads, it may hang and cause a freeze
-    void refreshEnvironments() {
+    private void refreshEnvironments() {
 
         var stopWatch = StopWatch.createStarted();
+
+        envChangeLock.lock();
 
         try {
             Log.log(LOGGER::debug, "Refresh Environments called");
@@ -216,19 +164,27 @@ public class Environment implements EnvironmentsSupplier {
                 return;
             }
 
-            replaceEnvironmentsListAndFireChange(newEnvironments);
+            this.environments = newEnvironments;
+            notifyEnvironmentsListChange();
+
         } finally {
+
+            if (envChangeLock.isHeldByCurrentThread()) {
+                envChangeLock.unlock();
+            }
+
             stopWatch.stop();
             Log.log(LOGGER::debug, "Refresh environments took {} milliseconds", stopWatch.getTime(TimeUnit.MILLISECONDS));
         }
     }
 
 
-    void replaceEnvironmentsList(@NotNull List<String> envs) {
-        this.environments = envs;
+    private void updateCurrentEnv(@Nullable String preferred, boolean refreshInsightsView) {
 
-        if (this.environments.contains(persistenceData.getCurrentEnv())) {
-            current = persistenceData.getCurrentEnv();
+        var oldEnv = current;
+
+        if (preferred != null && this.environments.contains(preferred)) {
+            current = preferred;
         } else if (current == null || !this.environments.contains(current)) {
             current = environments.isEmpty() ? null : environments.get(0);
         }
@@ -238,21 +194,9 @@ public class Environment implements EnvironmentsSupplier {
             //so when connection is back the current env can be restored to the last one.
             persistenceData.setCurrentEnv(current);
         }
-    }
-
-
-    //this method may be called from both ui threads or background threads
-    void replaceEnvironmentsListAndFireChange(@NotNull List<String> envs) {
-        Log.log(LOGGER::debug, "replaceEnvironmentsListAndFireChange called");
-
-        var oldEnv = current;
-
-        replaceEnvironmentsList(envs);
-
-        notifyEnvironmentsListChange();
 
         if (!Objects.equals(oldEnv, current)) {
-            notifyEnvironmentChanged(oldEnv, current);
+            notifyEnvironmentChanged(oldEnv, current, refreshInsightsView);
         }
     }
 
@@ -275,22 +219,29 @@ public class Environment implements EnvironmentsSupplier {
         if (project.isDisposed()) {
             return;
         }
-        EnvironmentChanged publisher = project.getMessageBus().syncPublisher(EnvironmentChanged.ENVIRONMENT_CHANGED_TOPIC);
-        publisher.environmentsListChanged(environments);
+
+        //run in new background thread so locks can be freeied because this method is called under lock
+        Backgroundable.runInNewBackgroundThread(project, "environmentsListChanged", () -> {
+            EnvironmentChanged publisher = project.getMessageBus().syncPublisher(EnvironmentChanged.ENVIRONMENT_CHANGED_TOPIC);
+            publisher.environmentsListChanged(environments);
+        });
+
     }
 
-    private void notifyEnvironmentChanged(String oldEnv, String newEnv) {
-        notifyEnvironmentChanged(oldEnv,newEnv,true);
-    }
 
-    private void notifyEnvironmentChanged(String oldEnv, String newEnv,boolean refreshInsightsView) {
+    private void notifyEnvironmentChanged(String oldEnv, String newEnv, boolean refreshInsightsView) {
         Log.log(LOGGER::debug, "Firing EnvironmentChanged event for {}", newEnv);
         if (project.isDisposed()) {
             return;
         }
+
         Log.log(LOGGER::info, "Digma: Changing environment " + oldEnv + " to " + newEnv);
-        EnvironmentChanged publisher = project.getMessageBus().syncPublisher(EnvironmentChanged.ENVIRONMENT_CHANGED_TOPIC);
-        publisher.environmentChanged(newEnv,refreshInsightsView);
+
+        //run in new background thread so locks can be freeied because this method is called under lock
+        Backgroundable.runInNewBackgroundThread(project, "environmentChanged", () -> {
+            EnvironmentChanged publisher = project.getMessageBus().syncPublisher(EnvironmentChanged.ENVIRONMENT_CHANGED_TOPIC);
+            publisher.environmentChanged(newEnv, refreshInsightsView);
+        });
     }
 
 }

--- a/ide-common/src/main/java/org/digma/intellij/plugin/refreshInsightsTask/RefreshService.kt
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/refreshInsightsTask/RefreshService.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.rd.util.withUiContext
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.RunnableCallable
 import com.intellij.util.concurrency.NonUrgentExecutor
-import org.digma.intellij.plugin.analytics.BackendConnectionUtil
 import org.digma.intellij.plugin.common.Backgroundable
 import org.digma.intellij.plugin.document.DocumentInfoContainer
 import org.digma.intellij.plugin.document.DocumentInfoService
@@ -58,9 +57,6 @@ class RefreshService(private val project: Project) {
         } else {
             val documentInfoContainer = documentInfoService.getDocumentInfo(file)
             updateInsightsCacheForActiveDocument(selectedTextEditor, documentInfoContainer)
-
-            Log.log(logger::debug, "testConnectionToBackend was triggered")
-            BackendConnectionUtil.getInstance(project).testConnectionToBackend()
 
             scope = insightsViewService.model.scope
             if (scope is CodeLessSpanScope){

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/analytics/BackendConnectionUtil.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/analytics/BackendConnectionUtil.kt
@@ -26,14 +26,11 @@ class BackendConnectionUtil(project: Project) {
 
     fun testConnectionToBackend(): Boolean {
 
-        //refresh will run in the background.
-        //if there is currently no connection, but connection will recover during this refresh call then
-        //not sure backendConnectionMonitor will catch it in time.
-        //the next call will return the latest connection status
-        //but anyway if the connection will recover an environmentChanged event will fire and that should
-        // be a hook to intentionally cause a contextChange event.
-        Log.log(logger::debug,"Triggering environmentsSupplier.refresh")
-        environmentsSupplier.refresh()
+        //if called on background thread refreshNowOnBackground will run on the same thread ,
+        // otherwise refreshNowOnBackground will run on background and isConnectionOk will return old result,
+        // next call will be ok
+        Log.log(logger::debug, "Triggering environmentsSupplier.refresh")
+        environmentsSupplier.refreshNowOnBackground()
 
         return backendConnectionMonitor.isConnectionOk()
     }

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/analytics/EnvironmentRefreshScheduler.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/analytics/EnvironmentRefreshScheduler.kt
@@ -3,7 +3,6 @@ package org.digma.intellij.plugin.analytics
 import com.intellij.collaboration.async.DisposingScope
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.service
-import com.intellij.openapi.project.Project
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -11,11 +10,11 @@ import org.digma.intellij.plugin.settings.SettingsState
 
 
 @Suppress("UnstableApiUsage")
-fun scheduleEnvironmentRefresh(project: Project, parentDisposable: Disposable, environemnt: Environment) {
+fun scheduleEnvironmentRefresh(parentDisposable: Disposable, environemnt: Environment) {
 
     DisposingScope(parentDisposable).launch {
         while (this.isActive) {
-            delay(project.service<SettingsState>().refreshDelay.toLong() * 1000)
+            delay(service<SettingsState>().refreshDelay.toLong() * 1000)
             environemnt.refreshNowOnBackground()
         }
     }

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/analytics/EnvironmentRefreshScheduler.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/analytics/EnvironmentRefreshScheduler.kt
@@ -1,0 +1,22 @@
+package org.digma.intellij.plugin.analytics
+
+import com.intellij.collaboration.async.DisposingScope
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.digma.intellij.plugin.settings.SettingsState
+
+
+@Suppress("UnstableApiUsage")
+fun scheduleEnvironmentRefresh(project: Project, parentDisposable: Disposable, environemnt: Environment) {
+
+    DisposingScope(parentDisposable).launch {
+        while (this.isActive) {
+            delay(project.service<SettingsState>().refreshDelay.toLong() * 1000)
+            environemnt.refreshNowOnBackground()
+        }
+    }
+}

--- a/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/environment/EnvironmentsSupplier.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/ui/model/environment/EnvironmentsSupplier.kt
@@ -3,20 +3,17 @@ package org.digma.intellij.plugin.ui.model.environment
 interface EnvironmentsSupplier {
 
     fun getEnvironments(): List<String>
-    fun setCurrent(selectedItem: String?)
 
-    fun setCurrent(selectedItem: String?, forceChange: Boolean)
+    fun setCurrent(selectedItem: String?)
 
     /**
      * a variant of setCurrent that notifies all listeners not to update the insights view. and will run a task right
      * after the environment was changed so that this task will see the new environment, the task should run even if the
      * environment didn't change, so this task must run if its not null
      */
-    fun setCurrent(selectedItem: String?, refreshInsightsView: Boolean, taskToRunAfterChange: Runnable?)
-    fun setCurrent(selectedItem: String?, refreshInsightsView: Boolean, forceChange: Boolean, taskToRunAfterChange: Runnable?)
-
+    fun setCurrent(selectedItem: String, refreshInsightsView: Boolean, taskToRunAfterChange: Runnable?)
 
     fun getCurrent(): String?
-    fun refresh()
+
     fun refreshNowOnBackground()
 }


### PR DESCRIPTION
there are few triggers for environment refresh:
a scheduler that triggers every 10 seconds, its the default and can be changed from settings.
when calling BackendConnectionUtil.testConnectionToBackend.
when the cursor moves between methods.

Something to consider:
we now have a few schedulers in the plugin, each occupies a thread and resources:
environment refresh,
insights refresh,
recent activity refresh,
live view refresh,

we can probably merge the login into one scheduler

