### PR TITLE
Feature/add dep of Digma Spring Boot Micrometer Autoconf

### DIFF
--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/deps/ModulesDepsService.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/deps/ModulesDepsService.kt
@@ -63,6 +63,7 @@ class ModulesDepsService(private val project: Project) : Disposable {
             var hasSpringBootStarterActuator = false
             var hasMicrometerTracingBridgeOtel = false
             var hasOtelExporterOtlp = false
+            var hasDigmaSpringBootMicrometerAutoconf = false
             var springBootVersion: String? = null
 
 
@@ -98,13 +99,18 @@ class ModulesDepsService(private val project: Project) : Disposable {
                 if (!hasOtelExporterOtlp) {
                     hasOtelExporterOtlp = checkOtelExporterOtlp(libCoord)
                 }
+                // spring boot + digma (aspect for @Observed)
+                if (!hasDigmaSpringBootMicrometerAutoconf) {
+                    hasDigmaSpringBootMicrometerAutoconf = checkDigmaSpringBootMicrometerAutoconf(libCoord)
+                }
 
                 // other
             }
 
             return ModuleMetadata(
                 hasOpenTelemetryAnnotations, quarkusVersion, hasQuarkusOpenTelemetry,
-                springBootVersion, hasSpringBootStarterActuator, hasMicrometerTracingBridgeOtel, hasOtelExporterOtlp
+                springBootVersion, hasSpringBootStarterActuator, hasMicrometerTracingBridgeOtel, hasOtelExporterOtlp,
+                hasDigmaSpringBootMicrometerAutoconf
             )
         }
 
@@ -146,6 +152,11 @@ class ModulesDepsService(private val project: Project) : Disposable {
                     libCoord.artifactId == "opentelemetry-exporter-otlp"
         }
 
+        @JvmStatic
+        fun checkDigmaSpringBootMicrometerAutoconf(libCoord: UnifiedCoordinates): Boolean {
+            return libCoord.groupId == "io.github.digma-ai" &&
+                    libCoord.artifactId == "digma-spring-boot-micrometer-tracing-autoconf"
+        }
 
     }
 
@@ -217,6 +228,7 @@ class ModulesDepsService(private val project: Project) : Disposable {
                     || !it.metadata.hasSpringBootStarterActuator
                     || !it.metadata.hasMicrometerTracingBridgeOtel
                     || !it.metadata.hasOtelExporterOtlp
+                    || !it.metadata.hasDigmaSpringBootMicrometerAutoconf
                     )
         }.toSet()
     }
@@ -250,6 +262,7 @@ data class ModuleMetadata(
     val hasSpringBootStarterActuator: Boolean,
     val hasMicrometerTracingBridgeOtel: Boolean,
     val hasOtelExporterOtlp: Boolean,
+    val hasDigmaSpringBootMicrometerAutoconf: Boolean,
     // other
 ) {
     fun hasQuarkus(): Boolean {

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
@@ -35,6 +35,8 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
 
         val MicrometerTracingBridgeOtelCoordinates = UnifiedCoordinates("io.micrometer", "micrometer-tracing-bridge-otel", "1.1.2")
         val OtelExporterOtlpCoordinates = UnifiedCoordinates("io.opentelemetry", "opentelemetry-exporter-otlp", "1.26.0")
+        val DigmaSpringBootMicrometerAutoconfCoordinates =
+            UnifiedCoordinates("io.github.digma-ai", "digma-spring-boot-micrometer-tracing-autoconf", "0.7.2")
 
         @JvmStatic
         fun getInstance(project: Project): SpringBootMicrometerConfigureDepsService {
@@ -132,6 +134,9 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
         }
         if (!moduleExt.metadata.hasOtelExporterOtlp) {
             uniDeps.add(buildUnifiedDependency(OtelExporterOtlpCoordinates, moduleBuildSystem))
+        }
+        if (!moduleExt.metadata.hasDigmaSpringBootMicrometerAutoconf) {
+            uniDeps.add(buildUnifiedDependency(DigmaSpringBootMicrometerAutoconfCoordinates, moduleBuildSystem))
         }
 
         println("adding spring boot deps to module '${module.name}' deps: ${uniDeps}")


### PR DESCRIPTION
relates to issue #859 .
relates to PR #934 and backend PR https://github.com/digma-ai/otel-java-instrumentation/pull/26

adding extra dependency to digma 

`implementation 'io.github.digma-ai:digma-spring-boot-micrometer-tracing-autoconf:0.7.2'`