### PR TITLE
Fixes/SpringBootMicrometer - OTLP GRPC 

### DIFF
--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/deps/ModulesDepsService.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/deps/ModulesDepsService.kt
@@ -63,6 +63,7 @@ class ModulesDepsService(private val project: Project) : Disposable {
 
             // spring boot
             var hasSpringBootStarterActuator = false
+            var hasSpringBootStarterAop = false
             var hasMicrometerTracingBridgeOtel = false
             var hasOtelExporterOtlp = false
             var hasDigmaSpringBootMicrometerAutoconf = false
@@ -97,6 +98,9 @@ class ModulesDepsService(private val project: Project) : Disposable {
                 }
                 if (!hasSpringBootStarterActuator) {
                     hasSpringBootStarterActuator = checkSpringBootStarterActuator(libCoord)
+                }
+                if (!hasSpringBootStarterAop) {
+                    hasSpringBootStarterAop = checkSpringBootStarterAop(libCoord)
                 }
                 if (!hasMicrometerTracingBridgeOtel) {
                     hasMicrometerTracingBridgeOtel = checkMicrometerTracingBridgeOtel(libCoord)
@@ -136,7 +140,8 @@ class ModulesDepsService(private val project: Project) : Disposable {
 
             return ModuleMetadata(
                 hasOpenTelemetryAnnotations, quarkusVersion, hasQuarkusOpenTelemetry,
-                springBootVersion, hasSpringBootStarterActuator, hasMicrometerTracingBridgeOtel, hasOtelExporterOtlp,
+                springBootVersion, hasSpringBootStarterActuator, hasSpringBootStarterAop,
+                hasMicrometerTracingBridgeOtel, hasOtelExporterOtlp,
                 hasDigmaSpringBootMicrometerAutoconf, micronautVersion, dropwizardVersion, springVersion
             )
         }
@@ -180,6 +185,12 @@ class ModulesDepsService(private val project: Project) : Disposable {
         fun checkSpringBootStarterActuator(libCoord: UnifiedCoordinates): Boolean {
             return libCoord.groupId == "org.springframework.boot" &&
                     libCoord.artifactId == "spring-boot-starter-actuator"
+        }
+
+        @JvmStatic
+        fun checkSpringBootStarterAop(libCoord: UnifiedCoordinates): Boolean {
+            return libCoord.groupId == "org.springframework.boot" &&
+                    libCoord.artifactId == "spring-boot-starter-aop"
         }
 
         @JvmStatic
@@ -305,6 +316,7 @@ class ModulesDepsService(private val project: Project) : Disposable {
     fun isModuleHasNeededDependenciesForSpringBootWithMicrometer(metadata: ModuleMetadata): Boolean {
         val retval = (true
                 && metadata.hasSpringBootStarterActuator
+                && metadata.hasSpringBootStarterAop
                 && metadata.hasMicrometerTracingBridgeOtel
                 && metadata.hasOtelExporterOtlp
                 && metadata.hasDigmaSpringBootMicrometerAutoconf
@@ -349,6 +361,7 @@ data class ModuleMetadata(
     // spring boot
     val springBootVersion: String?,
     val hasSpringBootStarterActuator: Boolean,
+    val hasSpringBootStarterAop: Boolean,
     val hasMicrometerTracingBridgeOtel: Boolean,
     val hasOtelExporterOtlp: Boolean,
     val hasDigmaSpringBootMicrometerAutoconf: Boolean,

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
@@ -36,7 +36,7 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
         val MicrometerTracingBridgeOtelCoordinates = UnifiedCoordinates("io.micrometer", "micrometer-tracing-bridge-otel", "1.1.2")
         val OtelExporterOtlpCoordinates = UnifiedCoordinates("io.opentelemetry", "opentelemetry-exporter-otlp", "1.26.0")
         val DigmaSpringBootMicrometerAutoconfCoordinates =
-            UnifiedCoordinates("io.github.digma-ai", "digma-spring-boot-micrometer-tracing-autoconf", "0.7.2")
+            UnifiedCoordinates("io.github.digma-ai", "digma-spring-boot-micrometer-tracing-autoconf", "0.7.4")
 
         @JvmStatic
         fun getInstance(project: Project): SpringBootMicrometerConfigureDepsService {
@@ -45,6 +45,12 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
 
         fun getSpringBootStarterActuatorDependency(javaBuildSystem: JavaBuildSystem, springBootVersion: String): UnifiedDependency {
             val libCoordinates = UnifiedCoordinates("org.springframework.boot", "spring-boot-starter-actuator", springBootVersion)
+
+            return buildUnifiedDependency(libCoordinates, javaBuildSystem)
+        }
+
+        fun getSpringBootStarterAopDependency(javaBuildSystem: JavaBuildSystem, springBootVersion: String): UnifiedDependency {
+            val libCoordinates = UnifiedCoordinates("org.springframework.boot", "spring-boot-starter-aop", springBootVersion)
 
             return buildUnifiedDependency(libCoordinates, javaBuildSystem)
         }
@@ -128,6 +134,9 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
         val uniDeps = mutableSetOf<UnifiedDependency>()
         if (!moduleExt.metadata.hasSpringBootStarterActuator) {
             uniDeps.add(getSpringBootStarterActuatorDependency(moduleBuildSystem, moduleExt.metadata.springBootVersion!!))
+        }
+        if (!moduleExt.metadata.hasSpringBootStarterAop) {
+            uniDeps.add(getSpringBootStarterAopDependency(moduleBuildSystem, moduleExt.metadata.springBootVersion!!))
         }
         if (!moduleExt.metadata.hasMicrometerTracingBridgeOtel) {
             uniDeps.add(buildUnifiedDependency(MicrometerTracingBridgeOtelCoordinates, moduleBuildSystem))


### PR DESCRIPTION
Roni's notes:

```
1. We are using the wrong system property for OTLP endpoint
2. We need to address the fact that the default is HTTP and not GRPC
3. The client-side discovery is not working for the navigation
4. We need to remove the version numbers from the dependencies
5. We might be missing aop?
```

this PR addresses
1. using the right entry name `management.otlp.tracing.endpoint`
2. we use OtlpGrpcSpanExporter by [digma 0.7.4](https://github.com/digma-ai/otel-java-instrumentation/pull/27)
3. could not see the problem
4. will be handled in different PR
5. yes added `spring-boot-starter-aop`