### PR TITLE
Feature/report task names for run config

### DIFF
--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/QuarkusRunConfigurationWrapper.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/QuarkusRunConfigurationWrapper.kt
@@ -1,6 +1,6 @@
 package org.digma.intellij.plugin.idea.runcfg
 
-import com.intellij.execution.JavaRunConfigurationBase
+import com.intellij.execution.JavaTestConfigurationBase
 import com.intellij.execution.configurations.JavaParameters
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunnerSettings
@@ -12,6 +12,7 @@ import org.digma.intellij.plugin.settings.SettingsState
 import org.jetbrains.idea.maven.execution.MavenRunConfiguration
 import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
 
+//
 // this class is derived from AutoOtelAgentRunConfigurationExtension.
 // consider to combine them together with abstract class
 //
@@ -167,7 +168,7 @@ class QuarkusRunConfigurationWrapper : IRunConfigurationWrapper {
     }
 
     private fun isJavaTest(configuration: RunConfigurationBase<*>, module: Module?): Boolean {
-        if (configuration is JavaRunConfigurationBase) {
+        if (configuration is JavaTestConfigurationBase) {
             if (isQuarkusModule(module)) {
                 return true
             }


### PR DESCRIPTION
adding entry named `task.names` to event of `run config`

for gradle task seeing:

![image](https://github.com/digma-ai/digma-intellij-plugin/assets/104715391/eae941d1-9bd5-46af-8eed-37304230ff53)

Maven + Quarkus:

![image](https://github.com/digma-ai/digma-intellij-plugin/assets/104715391/b2ca6960-3bba-40cc-99e6-da528c604f23)

