### PR TITLE
Bug fix/jaeger links to spans

### DIFF
--- a/src/main/java/org/digma/intellij/plugin/jaegerui/JaegerUIService.java
+++ b/src/main/java/org/digma/intellij/plugin/jaegerui/JaegerUIService.java
@@ -268,7 +268,7 @@ public class JaegerUIService {
                 var spanWorkspaceUris = ReadActions.ensureReadAction(() -> languageService.findWorkspaceUrisForSpanIds(spanIds));
                 var methodWorkspaceUris = ReadActions.ensureReadAction(() -> languageService.findWorkspaceUrisForMethodCodeObjectIds(methodIds));
                 spansMessage.payload().spans().forEach(span -> {
-                    var spanId = span.id();
+                    var spanId = span.spanId();
                     var methodId = span.methodId();
                     var hasCodeLocation = (spanWorkspaceUris.containsKey(spanId) || methodWorkspaceUris.containsKey(methodId));
 


### PR DESCRIPTION
the jaeger links to spans stopped working if span doesn't have method code object id related to it.

it happens since PR #744 

seems like we took the RAW spanID (which is used for neto jaeger), 
instead of spanCodeObjectId