### PR TITLE
Otel agent jars

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.14.1")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.22")
     implementation("com.glovoapp.gradle:versioning:1.1.10")
+    implementation("de.undercouch:gradle-download-task:5.4.0")
 }
 
 

--- a/buildSrc/src/main/kotlin/digma-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/digma-base.gradle.kts
@@ -3,6 +3,7 @@ import common.properties
 
 plugins {
     id("java")
+    id("de.undercouch.download")
 }
 
 

--- a/ide-common/src/main/java/org/digma/intellij/plugin/common/Retries.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/common/Retries.java
@@ -17,10 +17,11 @@ public class Retries {
     private static void simpleRetry(Runnable runnable,Class<? extends Throwable> retryOn,int backOffMillis,int maxRetries,int retryCount){
 
         try{
+            Log.log(LOGGER::debug,"starting retry "+retryCount);
             runnable.run();
         }catch (Throwable e){
 
-            Log.log(LOGGER::warn,"get exception "+e+ " retry "+retryCount);
+            Log.log(LOGGER::warn,"got exception "+e+ " retry "+retryCount);
             Log.warnWithException(LOGGER,e,"exception in simpleRetry");
 
             if (retryCount == maxRetries){
@@ -31,7 +32,7 @@ public class Retries {
 
             if (retryOn.isAssignableFrom(e.getClass())){
                 try {
-                    Log.log(LOGGER::warn,"sleeping");
+                    Log.log(LOGGER::warn,"sleeping {} millis",backOffMillis);
                     Thread.sleep(backOffMillis);
                 } catch (InterruptedException ex) {/* ignore*/}
                 simpleRetry(runnable,retryOn,backOffMillis,maxRetries,retryCount+1);

--- a/ide-common/src/main/java/org/digma/intellij/plugin/common/Retries.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/common/Retries.java
@@ -3,7 +3,6 @@ package org.digma.intellij.plugin.common;
 import com.intellij.openapi.diagnostic.Logger;
 import org.digma.intellij.plugin.log.Log;
 
-@Deprecated(forRemoval = true)// we have no use for this class
 public class Retries {
 
     private Retries() {

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -2,6 +2,7 @@ import common.IdeFlavor
 import common.logBuildProfile
 import common.platformVersion
 import common.shouldDownloadSources
+import de.undercouch.gradle.tasks.download.Download
 
 plugins {
     id("plugin-library")
@@ -22,4 +23,23 @@ intellij {
     version.set("$platformType-${project.platformVersion()}")
     plugins.set(listOf("com.intellij.java", "org.jetbrains.idea.maven", "org.jetbrains.plugins.gradle"))
     downloadSources.set(project.shouldDownloadSources())
+}
+
+
+tasks{
+
+    val downloadOtelJars = register("downloadOtelJars",Download::class.java){
+        src(
+            listOf(
+                "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar",
+                "https://github.com/digma-ai/otel-java-instrumentation/releases/latest/download/digma-otel-agent-extension.jar")
+        )
+
+        dest(File(project.sourceSets.main.get().output.resourcesDir,"otelJars"))
+        overwrite(false)
+    }
+
+    processResources{
+        dependsOn(downloadOtelJars)
+    }
 }

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/AutoOtelAgentRunConfigurationWrapper.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/AutoOtelAgentRunConfigurationWrapper.kt
@@ -7,6 +7,7 @@ import com.intellij.execution.configurations.ModuleRunConfiguration
 import com.intellij.execution.configurations.ParametersList
 import com.intellij.execution.configurations.RunConfigurationBase
 import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
@@ -130,8 +131,8 @@ class AutoOtelAgentRunConfigurationWrapper : IRunConfigurationWrapper {
         isTest: Boolean,
     ): String? {
 
-        val otelAgentPath = OTELJarProvider.getInstance().getOtelAgentJarPath(project)
-        val digmaExtensionPath = OTELJarProvider.getInstance().getDigmaAgentExtensionJarPath(project)
+        val otelAgentPath = service<OTELJarProvider>().getOtelAgentJarPath()
+        val digmaExtensionPath = service<OTELJarProvider>().getDigmaAgentExtensionJarPath()
         if (otelAgentPath == null || digmaExtensionPath == null) {
             Log.log(
                 logger::warn,

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
@@ -1,173 +1,179 @@
 package org.digma.intellij.plugin.idea.runcfg
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.io.FileUtil
-import com.intellij.util.download.DownloadableFileService
-import com.intellij.util.download.FileDownloader
-import org.digma.intellij.plugin.common.Backgroundable
+import org.digma.intellij.plugin.common.Retries
 import org.digma.intellij.plugin.log.Log
 import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.locks.ReentrantLock
+import kotlin.io.path.deleteIfExists
 
-private const val TEMP_JARS_DIR_PREFIX = "temp-digma-otel-jars"
+private const val JARS_DIR_PREFIX = "digma-otel-jars"
+private const val RESOURCE_LOCATION = "otelJars"
+private const val OTEL_AGENT_JAR_URL =
+    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar"
+private const val DIGMA_AGENT_EXTENSION_JAR_URL =
+    "https://github.com/digma-ai/otel-java-instrumentation/releases/latest/download/digma-otel-agent-extension.jar"
+private const val OTEL_AGENT_JAR_NAME = "opentelemetry-javaagent.jar"
+private const val DIGMA_AGENT_EXTENSION_JAR_NAME = "digma-otel-agent-extension.jar"
 
+
+@Service(Service.Level.APP)
 class OTELJarProvider {
 
-    private val logger: Logger = Logger.getInstance(OTELJarProvider::class.java)
+    private val logger: Logger = Logger.getInstance(this::class.java)
 
-    private var downloadDir: File? = null
+    private val downloadDir: File = File(System.getProperty("java.io.tmpdir"), JARS_DIR_PREFIX)
 
     private val lock = ReentrantLock()
 
-    companion object{
-        @JvmStatic
-        fun getInstance():OTELJarProvider{
-            return ApplicationManager.getApplication().getService(OTELJarProvider::class.java)
-        }
+
+    init {
+        //unpack and download on service initialization.
+        //will happen per IDE session
+        Thread {
+            unpackFilesAndDownloadLatest()
+        }.start()
     }
 
 
-    fun getOtelAgentJarPath(project: Project):String?{
-        if (!ensureDownloaded(project)){
-            return null
-        }
-        val otelJar = getOtelAgentJar(project)
-        otelJar?.let {
-            if (it.exists()){
-                return it.absolutePath
-            }
-        }
-        return null
+    fun getOtelAgentJarPath(): String? {
+        ensureFilesExist()
+        val otelJar = getOtelAgentJar()
+        return if (otelJar.exists()) otelJar.absolutePath else null
     }
 
-    private fun getOtelAgentJar(project: Project):File?{
-        downloadDir?.let {
-            return File(it, OTEL_AGENT_JAR_NAME)
-        }
-        return null
+    private fun getOtelAgentJar(): File {
+        return File(downloadDir, OTEL_AGENT_JAR_NAME)
     }
 
 
-    fun getDigmaAgentExtensionJarPath(project: Project):String?{
-        if (!ensureDownloaded(project)){
-            return null
+    fun getDigmaAgentExtensionJarPath(): String? {
+        ensureFilesExist()
+        val digmaJar = getDigmaAgentExtensionJar()
+        return if (digmaJar.exists()) digmaJar.absolutePath else null
+    }
+
+    private fun getDigmaAgentExtensionJar(): File {
+        return File(downloadDir, DIGMA_AGENT_EXTENSION_JAR_NAME)
+    }
+
+
+    private fun ensureFilesExist() {
+
+        if (filesExist()) {
+            return
         }
-        val digmaJar = getDigmaAgentExtensionJar(project)
-        digmaJar?.let {
-            if (it.exists()){
-                return it.absolutePath
-            }
-        }
-        return null
+
+        unpackFilesAndDownloadLatest()
+
     }
 
-    private fun getDigmaAgentExtensionJar(project: Project):File?{
-        downloadDir?.let {
-            return File(it, DIGMA_AGENT_EXTENSION_JAR_NAME)
-        }
-        return null
+    private fun filesExist(): Boolean {
+        val otelJar = getOtelAgentJar()
+        val digmaJar = getDigmaAgentExtensionJar()
+        return otelJar.exists() && digmaJar.exists()
     }
 
 
-    fun ensureDownloaded(project: Project,startup: Boolean = false): Boolean {
-        lock.lock()
-        try {
-            if (filesExist(project)){
-                return true
-            }
-            if (downloadDir == null || !filesExist(project)) {
-                downloadDir = FileUtil.createTempDirectory(TEMP_JARS_DIR_PREFIX, null, true)
-                deleteOldDirsThatMayStillBeThere(downloadDir)
-                Log.log(logger::debug,"downloading otel agent jar to {}", downloadDir)
-                downloadJars(project,downloadDir!!,startup)
-                //on startup the download is in background so just return true
-                if (startup){
-                    return true
-                }
+    private fun unpackFilesAndDownloadLatest() {
 
-                if (!filesExist(project)){
-                    downloadDir!!.delete()
-                    downloadDir = null
-                    return false
-                }
-            }
-        } finally {
-            lock.unlock()
-        }
-        return true
-    }
-
-    private fun deleteOldDirsThatMayStillBeThere(nextDownloadDir: File?) {
-        nextDownloadDir?.let { dir ->
-            val parentDir = dir.parentFile
-            parentDir?.let {parentDir ->
-                parentDir.listFiles { file ->
-                    !file.name.equals(nextDownloadDir.name) && file.isDirectory && file.name.contains(TEMP_JARS_DIR_PREFIX)
-                }.forEach { dirToDelete ->
-                    Log.log(logger::debug,"deleting old temp dir {}", dirToDelete)
-                    dirToDelete.delete()
-                }
-            }
-        }
-    }
-
-    private fun filesExist(project: Project): Boolean {
-        val otelJar = getOtelAgentJar(project)
-        val digmaJar = getDigmaAgentExtensionJar(project)
-        return  (otelJar != null && otelJar.exists()) && (digmaJar != null && digmaJar.exists())
-    }
-
-
-    private fun downloadJars(project: Project, downloadDir: File,startup: Boolean) {
-        val otelAgentFileDescription = DownloadableFileService.getInstance().createFileDescription(OTEL_AGENT_JAR_URL,
-            OTEL_AGENT_JAR_NAME)
-        val digmaExtensionFileDescription = DownloadableFileService.getInstance().createFileDescription(
-            DIGMA_AGENT_EXTENSION_JAR_URL, DIGMA_AGENT_EXTENSION_JAR_NAME)
-        val downloader = DownloadableFileService.getInstance().createDownloader(listOf(otelAgentFileDescription,digmaExtensionFileDescription),"otel agent jars")
-        download(downloader,project,downloadDir,startup)
-    }
-
-
-
-    private fun download(downloader: FileDownloader, project: Project, downloadDir: File,startup: Boolean){
-        if (startup){
-            downloadInBackground(downloader,project, downloadDir)
-        }else{
-            downloadWithProgress(downloader,project, downloadDir)
-        }
-    }
-
-    private fun downloadInBackground(downloader: FileDownloader, project: Project, downloadDir: File) {
-
-        Backgroundable.ensureBackground(project, "download otel agent jars") {
+        withLock {
             try {
-                downloader.download(downloadDir)
-                Log.log(logger::debug,"otel agent jars downloaded to {}",downloadDir)
+                if (!downloadDir.exists()) {
+                    if (!downloadDir.mkdirs()) {
+                        Log.log(logger::warn, "could not create directory for otel jars {}", downloadDir)
+                    }
+                }
+
+                if (downloadDir.exists()) {
+                    copyFileFromResource(OTEL_AGENT_JAR_NAME)
+                    copyFileFromResource(DIGMA_AGENT_EXTENSION_JAR_NAME)
+                }
+            }catch (e: Exception){
+                Log.warnWithException(logger,e,"could not unpack otel jars, hopefully download will succeed.")
+            }
+        }
+
+        tryDownloadLatest()
+    }
+
+
+    private fun copyFileFromResource(fileName: String) {
+        val inputStream = this::class.java.getResourceAsStream("/$RESOURCE_LOCATION/$fileName")
+        if (inputStream == null) {
+            Log.log(logger::warn, "could not find file in resource folder {}", fileName)
+            return
+        }
+        val outputStream = FileOutputStream(File(downloadDir, fileName))
+        com.intellij.openapi.util.io.StreamUtil.copy(inputStream, outputStream)
+    }
+
+
+    private fun tryDownloadLatest() {
+
+        val runnable = Runnable {
+
+            try {
+                downloadAndCopyJar(URL(OTEL_AGENT_JAR_URL), getOtelAgentJar())
+                downloadAndCopyJar(URL(DIGMA_AGENT_EXTENSION_JAR_URL), getDigmaAgentExtensionJar())
             } catch (e: Exception) {
-                Log.debugWithException(logger, e, "Could not download otel agent jars")
+                Log.warnWithException(logger, e, "could not download latest otel jars")
             }
         }
+
+        Thread(runnable).start()
     }
 
 
-    private fun downloadWithProgress(downloader: FileDownloader, project: Project, downloadDir: File) {
+    private fun downloadAndCopyJar(url: URL, toFile: File) {
+
+        val tempFile = kotlin.io.path.createTempFile("tempJarFile", ".jar")
+
         try {
-            if (ApplicationManager.getApplication().isReadAccessAllowed){
-                downloader.download(downloadDir)
-            }else{
-                downloader.downloadFilesWithProgress(downloadDir.absolutePath, project, null)
-            }
-            if (filesExist(project)) {
-                Log.log(logger::debug, "otel agent jars downloaded to {}", downloadDir)
-            } else {
-                Log.log(logger::debug, "Could not download otel agent jars")
-            }
+
+            Retries.simpleRetry({
+
+                val connection = url.openConnection()
+                connection.connectTimeout = 5000
+                connection.readTimeout = 5000
+
+                connection.getInputStream().use {
+                    Files.copy(it, tempFile, StandardCopyOption.REPLACE_EXISTING)
+                }
+
+                withLock {
+                    try {
+                        Files.move(tempFile, toFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+                    } catch (e: Exception) {
+                        //ATOMIC_MOVE is not always supported so try again on exception
+                        Files.move(tempFile, toFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                    }
+                }
+
+            }, Throwable::class.java, 5000, 3)
+
         } catch (e: Exception) {
-            Log.debugWithException(logger, e, "Could not download otel agent jars")
+            Log.warnWithException(logger, e, "could not download file {}", url)
+        } finally {
+            tempFile.deleteIfExists()
         }
     }
 
+
+    private fun withLock(function: () -> Unit) {
+        try {
+            lock.lock()
+            function()
+        } finally {
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
 
 }

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
@@ -22,7 +22,7 @@ private const val OTEL_AGENT_JAR_NAME = "opentelemetry-javaagent.jar"
 private const val DIGMA_AGENT_EXTENSION_JAR_NAME = "digma-otel-agent-extension.jar"
 
 
-@Service(Service.Level.APP)
+//Do not change to light service with annotation because this service is only necessary for java in idea
 class OTELJarProvider {
 
     private val logger: Logger = Logger.getInstance(this::class.java)

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
@@ -69,6 +69,8 @@ class OTELJarProvider {
             return
         }
 
+        Log.log(logger::info,"otel jars do not exists, unpacking..")
+
         unpackFilesAndDownloadLatest()
 
     }
@@ -82,6 +84,8 @@ class OTELJarProvider {
 
     private fun unpackFilesAndDownloadLatest() {
 
+        Log.log(logger::info,"unpacking otel agent jars")
+
         withLock {
             try {
                 if (!downloadDir.exists()) {
@@ -93,6 +97,7 @@ class OTELJarProvider {
                 if (downloadDir.exists()) {
                     copyFileFromResource(OTEL_AGENT_JAR_NAME)
                     copyFileFromResource(DIGMA_AGENT_EXTENSION_JAR_NAME)
+                    Log.log(logger::info,"otel agent jars extracted to {}",downloadDir)
                 }
             }catch (e: Exception){
                 Log.warnWithException(logger,e,"could not unpack otel jars, hopefully download will succeed.")
@@ -109,12 +114,17 @@ class OTELJarProvider {
             Log.log(logger::warn, "could not find file in resource folder {}", fileName)
             return
         }
-        val outputStream = FileOutputStream(File(downloadDir, fileName))
+
+        val file = File(downloadDir, fileName)
+        val outputStream = FileOutputStream(file)
+        Log.log(logger::info,"unpacking {} to {}",fileName,file)
         com.intellij.openapi.util.io.StreamUtil.copy(inputStream, outputStream)
     }
 
 
     private fun tryDownloadLatest() {
+
+        Log.log(logger::info,"trying to download latest otel jars")
 
         val runnable = Runnable {
 
@@ -138,6 +148,8 @@ class OTELJarProvider {
 
             Retries.simpleRetry({
 
+                Log.log(logger::info,"downloading {}",url)
+
                 val connection = url.openConnection()
                 connection.connectTimeout = 5000
                 connection.readTimeout = 5000
@@ -147,6 +159,7 @@ class OTELJarProvider {
                 }
 
                 withLock {
+                    Log.log(logger::info,"copying downloaded file {} to {}",tempFile,toFile)
                     try {
                         Files.move(tempFile, toFile.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
                     } catch (e: Exception) {

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
@@ -97,7 +97,7 @@ class OTELJarProvider {
                 if (downloadDir.exists()) {
                     copyFileFromResource(OTEL_AGENT_JAR_NAME)
                     copyFileFromResource(DIGMA_AGENT_EXTENSION_JAR_NAME)
-                    Log.log(logger::info,"otel agent jars extracted to {}",downloadDir)
+                    Log.log(logger::info,"otel agent jars unpacked to {}",downloadDir)
                 }
             }catch (e: Exception){
                 Log.warnWithException(logger,e,"could not unpack otel jars, hopefully download will succeed.")
@@ -171,7 +171,7 @@ class OTELJarProvider {
             }, Throwable::class.java, 5000, 3)
 
         } catch (e: Exception) {
-            Log.warnWithException(logger, e, "could not download file {}", url)
+            Log.log(logger::warn, "could not download file {}, {}", url,e)
         } finally {
             tempFile.deleteIfExists()
         }

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProviderStartup.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProviderStartup.kt
@@ -1,11 +1,13 @@
 package org.digma.intellij.plugin.idea.runcfg
 
-import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 
-class OTELJarProviderStartup: StartupActivity {
+class OTELJarProviderStartup : StartupActivity {
     override fun runActivity(project: Project) {
-        ApplicationManager.getApplication().getService(OTELJarProvider::class.java).ensureDownloaded(project,true)
+        //just call the service so its initializes if it's the first IDE startup.
+        //opening more projects will do nothing because it's an application service.
+        service<OTELJarProvider>()
     }
 }

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/constants.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/constants.kt
@@ -2,10 +2,6 @@ package org.digma.intellij.plugin.idea.runcfg
 
 const val JAVA_TOOL_OPTIONS = "JAVA_TOOL_OPTIONS"
 
-const val OTEL_AGENT_JAR_URL = "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar"
-const val DIGMA_AGENT_EXTENSION_JAR_URL = "https://github.com/digma-ai/otel-java-instrumentation/releases/latest/download/digma-otel-agent-extension.jar"
-const val OTEL_AGENT_JAR_NAME = "opentelemetry-javaagent.jar"
-const val DIGMA_AGENT_EXTENSION_JAR_NAME = "digma-otel-agent-extension.jar"
 
 val KNOWN_IRRELEVANT_TASKS = setOf(
     /*

--- a/src/main/resources/META-INF/org.digma.intellij-with-java.xml
+++ b/src/main/resources/META-INF/org.digma.intellij-with-java.xml
@@ -14,6 +14,8 @@
         <projectService serviceImplementation="org.digma.intellij.plugin.idea.psi.java.JavaCodeLensService"/>
 
         <projectService serviceImplementation="org.digma.intellij.plugin.idea.runcfg.AutoOtelAgentRunConfigurationWrapper"/>
+
+        <applicationService serviceImplementation="org.digma.intellij.plugin.idea.runcfg.OTELJarProvider"/>
         <postStartupActivity implementation="org.digma.intellij.plugin.idea.runcfg.OTELJarProviderStartup"/>
 
         <projectService serviceImplementation="org.digma.intellij.plugin.idea.deps.ModulesDepsService"/>

--- a/src/main/resources/META-INF/org.digma.intellij-with-java.xml
+++ b/src/main/resources/META-INF/org.digma.intellij-with-java.xml
@@ -14,7 +14,6 @@
         <projectService serviceImplementation="org.digma.intellij.plugin.idea.psi.java.JavaCodeLensService"/>
 
         <projectService serviceImplementation="org.digma.intellij.plugin.idea.runcfg.AutoOtelAgentRunConfigurationWrapper"/>
-        <applicationService serviceImplementation="org.digma.intellij.plugin.idea.runcfg.OTELJarProvider"/>
         <postStartupActivity implementation="org.digma.intellij.plugin.idea.runcfg.OTELJarProviderStartup"/>
 
         <projectService serviceImplementation="org.digma.intellij.plugin.idea.deps.ModulesDepsService"/>


### PR DESCRIPTION
This PR changes the way otel jars are downloaded:

the two jars are downloaded on every gradle build and packaged in the plugin zip in the java module jar under a directory otelJars.
that means internet connection is necessary when building. to use gradle offline do not clean. after gradle clean a connection is necessary.

when the IDE starts, the two jars are unpacked to /tmp/digma-otel-jars or whatever is the temp directory on the machine as returned by System.getProperty("java.io.tmpdir").
after unpacking the jars are ready for use.
after unpacking the jars, a background thread will attempt to download the latest jars from github, if succeeds it will override the files in /tmp/digma-otel-jars

the jars are never deleted by the plugin and are there as long as the IDE is up. they are unpacked again every time the IDE restarts. so when updating the plugin the new jars will be unpacked because the plugin requires restart.
when opening more projects the jars are untouched and not unpacked again. 

if the jars are deleted while the IDE is up they will be unpacked again when required. and again an attempt will be made to download latest from github.

if downloading from github fails the unpacked jars are untouched and are available for use.

download is quite and unseen by the user. errors are logged.




