### PR TITLE
Package compose file for offline

### DIFF
--- a/ide-common/build.gradle.kts
+++ b/ide-common/build.gradle.kts
@@ -2,6 +2,7 @@ import common.dynamicPlatformType
 import common.logBuildProfile
 import common.platformVersion
 import common.shouldDownloadSources
+import de.undercouch.gradle.tasks.download.Download
 
 plugins {
     id("plugin-library")
@@ -34,3 +35,21 @@ dependencies {
     implementation(project(":analytics-provider"))
 }
 
+tasks{
+
+    val downloadComposeFile = register("downloadComposeFile", Download::class.java){
+        src(
+            listOf(
+                "https://get.digma.ai/")
+        )
+
+        val dir = File(project.sourceSets.main.get().output.resourcesDir,"docker-compose")
+        dest(File(dir,"docker-compose.yml"))
+        overwrite(false)
+        onlyIfModified(true)
+    }
+
+    processResources{
+        dependsOn(downloadComposeFile)
+    }
+}

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/docker/DockerService.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/docker/DockerService.kt
@@ -44,6 +44,12 @@ class DockerService {
         }
 
         downloader.deleteOldFileIfExists()
+
+        if (isEngineInstalled()){
+            //this will happen on IDE start,
+            // DockerService is an application service so Downloader will be created once per application
+            downloader.unpackAndTryDownloadLatest()
+        }
     }
 
 

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/docker/Downloader.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/docker/Downloader.kt
@@ -23,13 +23,8 @@ class Downloader {
     private val downloadDir: File = File(System.getProperty("java.io.tmpdir"), COMPOSE_FILE_DIR)
     val composeFile: File = File(downloadDir, COMPOSE_FILE_NAME)
 
-    init {
-        //this will happen on IDE start,
-        // DockerService is an application service so Downloader will be created once per application
-        unpackAndTryDownloadLatest()
-    }
 
-    private fun unpackAndTryDownloadLatest() {
+    fun unpackAndTryDownloadLatest() {
         unpack()
         tryDownloadLatest()
     }

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/docker/Engine.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/docker/Engine.kt
@@ -5,9 +5,9 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import org.digma.intellij.plugin.log.Log
 import org.digma.intellij.plugin.posthog.ActivityMonitor
+import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
-import java.nio.file.Path
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
@@ -21,13 +21,13 @@ internal class Engine {
     private val engineLock = ReentrantLock()
 
 
-    fun up(project: Project, composeFile: Path, dockerComposeCmd: List<String>): String {
+    fun up(project: Project, composeFile: File, dockerComposeCmd: List<String>): String {
 
         Log.log(logger::info, "starting docker compose up")
 
         val processBuilder = GeneralCommandLine(dockerComposeCmd)
-            .withParameters("-f", composeFile.toString(), "up", "-d")
-            .withWorkDirectory(composeFile.toFile().parentFile)
+            .withParameters("-f", composeFile.canonicalPath.toString(), "up", "-d")
+            .withWorkDirectory(composeFile.parentFile)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withRedirectErrorStream(true)
             .toProcessBuilder()
@@ -36,13 +36,13 @@ internal class Engine {
     }
 
 
-    fun down(project: Project, composeFile: Path, dockerComposeCmd: List<String>, reportToPosthog: Boolean = true): String {
+    fun down(project: Project, composeFile: File, dockerComposeCmd: List<String>, reportToPosthog: Boolean = true): String {
 
         Log.log(logger::info, "starting docker compose down")
 
         val processBuilder = GeneralCommandLine(dockerComposeCmd)
-            .withParameters("-f", composeFile.toString(), "down")
-            .withWorkDirectory(composeFile.toFile().parentFile)
+            .withParameters("-f", composeFile.canonicalPath.toString(), "down")
+            .withWorkDirectory(composeFile.parentFile)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withRedirectErrorStream(true)
             .toProcessBuilder()
@@ -52,13 +52,13 @@ internal class Engine {
     }
 
 
-    fun start(project: Project, composeFile: Path, dockerComposeCmd: List<String>): String {
+    fun start(project: Project, composeFile: File, dockerComposeCmd: List<String>): String {
 
         Log.log(logger::info, "starting docker compose start")
 
         val processBuilder = GeneralCommandLine(dockerComposeCmd)
-            .withParameters("-f", composeFile.toString(), "up", "-d")
-            .withWorkDirectory(composeFile.toFile().parentFile)
+            .withParameters("-f", composeFile.canonicalPath.toString(), "up", "-d")
+            .withWorkDirectory(composeFile.parentFile)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withRedirectErrorStream(true)
             .toProcessBuilder()
@@ -68,13 +68,13 @@ internal class Engine {
     }
 
 
-    fun stop(project: Project, composeFile: Path, dockerComposeCmd: List<String>): String {
+    fun stop(project: Project, composeFile: File, dockerComposeCmd: List<String>): String {
 
         Log.log(logger::info, "starting docker compose stop")
 
         val processBuilder = GeneralCommandLine(dockerComposeCmd)
-            .withParameters("-f", composeFile.toString(), "stop")
-            .withWorkDirectory(composeFile.toFile().parentFile)
+            .withParameters("-f", composeFile.canonicalPath.toString(), "stop")
+            .withWorkDirectory(composeFile.parentFile)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withRedirectErrorStream(true)
             .toProcessBuilder()
@@ -84,7 +84,7 @@ internal class Engine {
     }
 
 
-    fun remove(project: Project, composeFile: Path, dockerComposeCmd: List<String>): String {
+    fun remove(project: Project, composeFile: File, dockerComposeCmd: List<String>): String {
 
         Log.log(logger::info, "starting uninstall")
 
@@ -92,8 +92,8 @@ internal class Engine {
         //"-f", composeFile.toString(), "down", "--rmi", "all", "-v", "--remove-orphans"
 
         val processBuilder = GeneralCommandLine(dockerComposeCmd)
-            .withParameters("-f", composeFile.toString(), "down")
-            .withWorkDirectory(composeFile.toFile().parentFile)
+            .withParameters("-f", composeFile.canonicalPath.toString(), "down")
+            .withWorkDirectory(composeFile.parentFile)
             .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             .withRedirectErrorStream(true)
             .toProcessBuilder()
@@ -106,7 +106,7 @@ internal class Engine {
     private fun executeCommand(
         project: Project,
         name: String,
-        composeFile: Path,
+        composeFile: File,
         processBuilder: ProcessBuilder,
         reportToPosthog: Boolean = true,
     ): String {


### PR DESCRIPTION
This PR changed the way docker compose file is downloaded. and makes sure the file is available even if there is no internet connection.

the file is packaged on every build into the jar ide-common in folder docker-compose.

on startup, if local engine is installed the file is unpacked to /tmp/digma-docker or whatever is the temp directory on the machine as returned by System.getProperty("java.io.tmpdir").
after unpacking, the file is ready for use.
after unpacking , a background thread will attempt to download the latest file, if succeeds it will override the file in /tmp/digma-docker. if the download fails the unpacked file is untouched and available for use. 

if local engine is not installed the file will not be unpacked.

on DockerService.installEngine if the file does not exists in /tmp/digma-docker the file is unpacked and an attempt is made to download latest. if the download fails the unpacked file is untouched and available for use. 

the file is never deleted by the plugin , except when remove engine is called.
every time the file is needed and does not exist in  /tmp/digma-docker it is unpacked and an attempt is made to download latest.

on engine upgrade the latest file will be downloaded.


