### PR TITLE
update build profiles

### DIFF
--- a/.github/workflows/build-branches.yml
+++ b/.github/workflows/build-branches.yml
@@ -10,7 +10,7 @@ jobs:
   call-build-workflow:
     strategy:
       matrix:
-        profile: [ lowest, latest, eap ]
+        profile: [ p223, p231, p232 ]
     uses: ./.github/workflows/build-workflow.yml
     with:
       build-profile: ${{ matrix.profile }}

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -8,7 +8,7 @@ jobs:
   call-build-workflow:
     strategy:
       matrix:
-        profile: [ lowest, latest, eap ]
+        profile: [ p223, p231, p232 ]
     uses: ./.github/workflows/build-workflow.yml
     with:
       build-profile: ${{ matrix.profile }}
@@ -19,7 +19,7 @@ jobs:
   call-build-workflow-with-rider:
     strategy:
       matrix:
-        profile: [ lowest, latest, eap ]
+        profile: [ p223, p231, p232 ]
     uses: ./.github/workflows/build-workflow.yml
     with:
       build-profile: ${{ matrix.profile }}

--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -8,7 +8,7 @@ jobs:
   call-build-workflow:
     strategy:
       matrix:
-        profile: [ lowest, latest, eap ]
+        profile: [ p223, p231, p232 ]
     uses: ./.github/workflows/build-workflow.yml
     with:
       build-profile: ${{ matrix.profile }}

--- a/.github/workflows/publish-to-jetbrains-and-increment-version.yml
+++ b/.github/workflows/publish-to-jetbrains-and-increment-version.yml
@@ -9,7 +9,7 @@ jobs:
   call-publish-workflow:
     strategy:
       matrix:
-        profile: [ lowest, latest, eap ]
+        profile: [ p223, p231, p232 ]
     uses: ./.github/workflows/publish-workflow.yml
     with:
       build-profile: ${{ matrix.profile }}

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,6 +4,17 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT">
+            <builds>
+              <build path="$PROJECT_DIR$/buildSrc" name="buildSrc">
+                <projects>
+                  <project path="$PROJECT_DIR$/buildSrc" />
+                </projects>
+              </build>
+            </builds>
+          </compositeBuild>
+        </compositeConfiguration>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$USER_HOME$/.sdkman/candidates/gradle/current" />
         <option name="modules">

--- a/.run/Run IDEA Community - 2022.3.run.xml
+++ b/.run/Run IDEA Community - 2022.3.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Pycharm - Latest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PC.log" />
+  <configuration default="false" name="Run IDEA Community - 2022.3" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IC.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=latest"/>
+      <option name="scriptParameters" value="-PbuildProfile=p223"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run IDEA Community - 2023.1.run.xml
+++ b/.run/Run IDEA Community - 2023.1.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Rider - Latest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_RD.log" />
+  <configuration default="false" name="Run IDEA Community - 2023.1" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IC.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=latest"/>
+      <option name="scriptParameters" value="-PbuildProfile=p231"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run IDEA Community - 2023.2.run.xml
+++ b/.run/Run IDEA Community - 2023.2.run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run IDEA Community - 2023.2" type="GradleRunConfiguration"
+                   factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IC.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PbuildProfile=p232"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="buildPlugin"/>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.run/Run IDEA Community - EAP.run.xml
+++ b/.run/Run IDEA Community - EAP.run.xml
@@ -5,13 +5,13 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildProfile=eap"/>
+        <option name="scriptParameters" value="-PbuildProfile=eap"/>
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="buildPlugin"/>
+            <option value="buildPlugin"/>
           <option value="runIde" />
         </list>
       </option>

--- a/.run/Run IDEA Ultimate - 2022.3.run.xml
+++ b/.run/Run IDEA Ultimate - 2022.3.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run IDEA Community - Latest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IC.log" />
+  <configuration default="false" name="Run IDEA Ultimate - 2022.3" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IU.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildProfile=latest"/>
+      <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=p223"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run IDEA Ultimate - 2023.1.run.xml
+++ b/.run/Run IDEA Ultimate - 2023.1.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run IDEA Ultimate - Latest" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Run IDEA Ultimate - 2023.1" type="GradleRunConfiguration" factoryName="Gradle">
     <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IU.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=latest"/>
+      <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=p231"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run IDEA Ultimate - 2023.2.run.xml
+++ b/.run/Run IDEA Ultimate - 2023.2.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run IDEA Ultimate - 2023.2" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IU.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=p232"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="buildPlugin"/>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.run/Run IDEA Ultimate - EAP.run.xml
+++ b/.run/Run IDEA Ultimate - EAP.run.xml
@@ -5,13 +5,13 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=eap"/>
+        <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=eap"/>
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="buildPlugin"/>
+            <option value="buildPlugin"/>
           <option value="runIde" />
         </list>
       </option>

--- a/.run/Run Pycharm - 2022.3.run.xml
+++ b/.run/Run Pycharm - 2022.3.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Pycharm Pro - Lowest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PY.log" />
+  <configuration default="false" name="Run Pycharm - 2022.3" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PC.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=lowest"/>
+      <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=p223"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run Pycharm - 2023.1.run.xml
+++ b/.run/Run Pycharm - 2023.1.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Pycharm - Lowest" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Run Pycharm - 2023.1" type="GradleRunConfiguration" factoryName="Gradle">
     <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PC.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=lowest"/>
+      <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=p231"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run Pycharm - 2023.2.run.xml
+++ b/.run/Run Pycharm - 2023.2.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Pycharm - 2023.2" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PC.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=p232"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="buildPlugin"/>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.run/Run Pycharm - EAP.run.xml
+++ b/.run/Run Pycharm - EAP.run.xml
@@ -5,13 +5,13 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=eap"/>
+        <option name="scriptParameters" value="-PbuildWithPycharm=true -PbuildProfile=eap"/>
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="buildPlugin"/>
+            <option value="buildPlugin"/>
           <option value="runIde" />
         </list>
       </option>

--- a/.run/Run Pycharm Pro - 2022.3.run.xml
+++ b/.run/Run Pycharm Pro - 2022.3.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Rider - Lowest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_RD.log" />
+  <configuration default="false" name="Run Pycharm Pro - 2022.3" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PY.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=lowest"/>
+      <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=p223"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run Pycharm Pro - 2023.1.run.xml
+++ b/.run/Run Pycharm Pro - 2023.1.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run Pycharm Pro - Latest" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Run Pycharm Pro - 2023.1" type="GradleRunConfiguration" factoryName="Gradle">
     <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PY.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=latest"/>
+      <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=p231"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run Pycharm Pro - 2023.2.run.xml
+++ b/.run/Run Pycharm Pro - 2023.2.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Pycharm Pro - 2023.2" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_PY.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=p232"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="buildPlugin"/>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.run/Run Pycharm Pro - EAP.run.xml
+++ b/.run/Run Pycharm Pro - EAP.run.xml
@@ -5,13 +5,13 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=eap"/>
+        <option name="scriptParameters" value="-PbuildWithPycharmPro=true -PbuildProfile=eap"/>
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="buildPlugin"/>
+            <option value="buildPlugin"/>
           <option value="runIde" />
         </list>
       </option>

--- a/.run/Run Rider - 2022.3.run.xml
+++ b/.run/Run Rider - 2022.3.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run IDEA Community - Lowest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IC.log" />
+  <configuration default="false" name="Run Rider - 2022.3" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_RD.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildProfile=lowest"/>
+      <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=p223"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run Rider - 2023.1.run.xml
+++ b/.run/Run Rider - 2023.1.run.xml
@@ -1,11 +1,11 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run IDEA Ultimate - Lowest" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_IU.log" />
+  <configuration default="false" name="Run Rider - 2023.1" type="GradleRunConfiguration" factoryName="Gradle">
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_RD.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWIthUltimate=true -PbuildProfile=lowest"/>
+      <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=p231"/>
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run Rider - 2023.2.run.xml
+++ b/.run/Run Rider - 2023.2.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="false" name="Run Rider - 2023.2" type="GradleRunConfiguration" factoryName="Gradle">
+        <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea_RD.log"/>
+        <ExternalSystemSettings>
+            <option name="executionName"/>
+            <option name="externalProjectPath" value="$PROJECT_DIR$"/>
+            <option name="externalSystemIdString" value="GRADLE"/>
+            <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=p232"/>
+            <option name="taskDescriptions">
+                <list/>
+            </option>
+            <option name="taskNames">
+                <list>
+                    <option value="buildPlugin"/>
+                    <option value="runIde"/>
+                </list>
+            </option>
+            <option name="vmOptions" value=""/>
+        </ExternalSystemSettings>
+        <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+        <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+        <DebugAllEnabled>false</DebugAllEnabled>
+        <RunAsTest>false</RunAsTest>
+        <method v="2"/>
+    </configuration>
+</component>

--- a/.run/Run Rider - EAP.run.xml
+++ b/.run/Run Rider - EAP.run.xml
@@ -5,13 +5,13 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=eap"/>
+        <option name="scriptParameters" value="-PbuildWithRider=true -PbuildProfile=eap"/>
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="buildPlugin"/>
+            <option value="buildPlugin"/>
           <option value="runIde" />
         </list>
       </option>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,7 +246,7 @@ tasks {
 
         //rider EAP doesn't work here, plugin verifier can't find it
         withCurrentProfile { profile ->
-            if (profile.profile == BuildProfiles.Profiles.eap && platformType == IdeFlavor.RD.name) {
+            if (profile.isEAP && platformType == IdeFlavor.RD.name) {
                 enabled = false
             } else {
                 ideVersions.set(listOf("${platformType}-${profile.versionToRunPluginVerifier}"))

--- a/buildSrc/src/main/kotlin/common/BuildProfile.kt
+++ b/buildSrc/src/main/kotlin/common/BuildProfile.kt
@@ -70,39 +70,53 @@ fun Project.currentProfile(): BuildProfile = BuildProfiles.currentProfile(this)
 
 object BuildProfiles {
 
-    enum class Profiles { lowest, latest, eap }
+    enum class Profiles { p223, p231, p232, p233 }
 
     fun currentProfile(project: Project): BuildProfile {
 
         val selectedProfile = project.findProperty("buildProfile")?.let {
-            Profiles.valueOf(it as String)
-        } ?: Profiles.lowest
+
+            var profileToUse = it as String
+            if (profileAliases.containsKey(it)) {
+                profileToUse = profileAliases[it] as String
+            }
+
+            Profiles.valueOf(profileToUse)
+
+        } ?: Profiles.p223
 
         return profiles[selectedProfile] ?: throw GradleException("can not find profile $selectedProfile")
     }
 
+    //update as new profiles are added or removed
+    private val profileAliases = mapOf(
+        "lowest" to Profiles.p223.name,
+        "latest" to Profiles.p232.name,
+        "eap" to Profiles.p233.name,
+    )
+
 
     private val profiles = mapOf(
 
-        Profiles.lowest to BuildProfile(
-            profile = Profiles.lowest,
+        Profiles.p223 to BuildProfile(
+            profile = Profiles.p223,
             // platformVersion is Intellij IDEA Community and Ultimate
-            platformVersion = "2022.3.1",
-            riderVersion = "2022.3.1",
-            pycharmVersion = "2022.3.1",
-            riderResharperVersion = "2022.3.1",
+            platformVersion = "2022.3.3",
+            riderVersion = "2022.3.3",
+            pycharmVersion = "2022.3.3",
+            riderResharperVersion = "2022.3.3",
             riderResharperVersionConstant = "PROFILE_2022_3",
-            pythonPluginVersion = "223.7571.182",
+            pythonPluginVersion = "223.8836.26",
             platformVersionCode = "223",
             pluginSinceBuild = "223",
             pluginUntilBuild = "223.*",
-            versionToRunPluginVerifier = "2022.3.1",
+            versionToRunPluginVerifier = "2022.3.3",
             kotlinTarget = KotlinVersion.KOTLIN_1_7.version,
             javaVersion = JavaVersion.VERSION_17.majorVersion
         ),
 
-        Profiles.latest to BuildProfile(
-            profile = Profiles.latest,
+        Profiles.p231 to BuildProfile(
+            profile = Profiles.p231,
             // platformVersion is Intellij IDEA Community and Ultimate
             platformVersion = "2023.1.5",
             riderVersion = "2023.1.4",
@@ -113,20 +127,42 @@ object BuildProfiles {
             platformVersionCode = "231",
             pluginSinceBuild = "231",
             pluginUntilBuild = "231.*",
-            versionToRunPluginVerifier = "2023.1.5",
+            versionToRunPluginVerifier = "2023.1.4",
             kotlinTarget = KotlinVersion.KOTLIN_1_8.version,
             javaVersion = JavaVersion.VERSION_17.majorVersion
         ),
 
-        Profiles.eap to BuildProfile(
-            profile = Profiles.eap,
+        Profiles.p232 to BuildProfile(
+            profile = Profiles.p232,
             // platformVersion is Intellij IDEA Community and Ultimate
-            platformVersion = "2023.2",
-            riderVersion = "2023.2",
-            pycharmVersion = "2023.2",
+            platformVersion = "2023.2.1",
+            riderVersion = "2023.2.1",
+            pycharmVersion = "2023.2.1",
             riderResharperVersion = "2023.2.0",
             riderResharperVersionConstant = "PROFILE_2023_2",
-            pythonPluginVersion = "232.8660.185",
+            pythonPluginVersion = "232.9559.62",
+            platformVersionCode = "232",
+            pluginSinceBuild = "232",
+            pluginUntilBuild = "232.*",
+            versionToRunPluginVerifier = "2023.2.1",
+            kotlinTarget = KotlinVersion.KOTLIN_1_8.version,
+            javaVersion = JavaVersion.VERSION_17.majorVersion
+        ),
+
+
+        //todo: the next EAP profile. still not active and not built in github, versions are of p232 until EAP is started.
+        // update when 2023.3 starts and add to github workflows
+        Profiles.p233 to BuildProfile(
+
+            profile = Profiles.p233,
+            isEAP = true,
+            // platformVersion is Intellij IDEA Community and Ultimate
+            platformVersion = "2023.2.1",
+            riderVersion = "2023.2.1",
+            pycharmVersion = "2023.2.1",
+            riderResharperVersion = "2023.2.0",
+            riderResharperVersionConstant = "PROFILE_2023_2",
+            pythonPluginVersion = "232.9559.62",
             platformVersionCode = "232",
             pluginSinceBuild = "232",
             pluginUntilBuild = "232.*",
@@ -143,6 +179,7 @@ object BuildProfiles {
 
 data class BuildProfile(
     val profile: BuildProfiles.Profiles,
+    val isEAP: Boolean = false,
     val platformVersion: String,
     val riderVersion: String,
     val pycharmVersion: String,

--- a/building-how-to/build-all-examples.sh
+++ b/building-how-to/build-all-examples.sh
@@ -5,69 +5,69 @@
 set -e
 ###################   idea community
 
-# there is no need to send the lowest profile, its the default if not sent,its here just as example
+# there is no need to send the oldest profile, its the default if not sent,its here just as example
 
-./gradlew clean buildPlugin -PbuildProfile=lowest
-./gradlew clean buildPlugin -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildProfile=p223
+./gradlew clean buildPlugin -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildProfile=p232
 
 ## to run ide from command line
 ./gradlew clean buildPlugin runIde
-./gradlew clean buildPlugin runIde -PbuildProfile=latest
-./gradlew clean buildPlugin runIde -PbuildProfile=eap
+./gradlew clean buildPlugin runIde -PbuildProfile=p231
+./gradlew clean buildPlugin runIde -PbuildProfile=p232
 
 
 ## run idea community with python plugin installed , this is for testing that digma functions correctly
 ## when python plugin is installed.
 ## the python plugin version need to be updated when updating build profiles
-./gradlew clean runIde -PplatformPlugins=com.intellij.java,PythonCore:223.7571.182 -PbuildProfile=lowest
-./gradlew clean runIde -PplatformPlugins=com.intellij.java,PythonCore:231.8770.65 -PbuildProfile=latest
-./gradlew clean runIde -PplatformPlugins=com.intellij.java,PythonCore:232.8660.48 -PbuildProfile=eap
+./gradlew clean runIde -PplatformPlugins=com.intellij.java,PythonCore:223.7571.182 -PbuildProfile=p223
+./gradlew clean runIde -PplatformPlugins=com.intellij.java,PythonCore:231.8770.65 -PbuildProfile=p231
+./gradlew clean runIde -PplatformPlugins=com.intellij.java,PythonCore:232.8660.48 -PbuildProfile=p232
 
 
 ###################### idea ultimate
 
 ./gradlew clean buildPlugin -PbuildWIthUltimate=true
-./gradlew clean buildPlugin -PbuildWIthUltimate=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWIthUltimate=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWIthUltimate=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWIthUltimate=true -PbuildProfile=p232
 
 ## to run ide from command line
 ./gradlew clean buildPlugin runIde -PbuildWIthUltimate=true
-./gradlew clean buildPlugin runIde -PbuildWIthUltimate=true -PbuildProfile=latest
-./gradlew clean buildPlugin runIde -PbuildWIthUltimate=true -PbuildProfile=eap
+./gradlew clean buildPlugin runIde -PbuildWIthUltimate=true -PbuildProfile=p231
+./gradlew clean buildPlugin runIde -PbuildWIthUltimate=true -PbuildProfile=p232
 
 
 
 
 #################  rider
 ./gradlew clean buildPlugin -PbuildWithRider=true
-./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=p232
 
 ## to run ide from command line
 ./gradlew clean buildPlugin runIde -PbuildWithRider=true
-./gradlew clean buildPlugin runIde -PbuildWithRider=true -PbuildProfile=latest
-./gradlew clean buildPlugin runIde -PbuildWithRider=true -PbuildProfile=eap
+./gradlew clean buildPlugin runIde -PbuildWithRider=true -PbuildProfile=p231
+./gradlew clean buildPlugin runIde -PbuildWithRider=true -PbuildProfile=p232
 
 
 ######################  pycharm
 
 ./gradlew clean buildPlugin -PbuildWithPycharm=true
-./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=p232
 
 ## to run ide from command line
 ./gradlew clean buildPlugin runIde -PbuildWithPycharm=true
-./gradlew clean buildPlugin runIde -PbuildWithPycharm=true -PbuildProfile=latest
-./gradlew clean buildPlugin runIde -PbuildWithPycharm=true -PbuildProfile=eap
+./gradlew clean buildPlugin runIde -PbuildWithPycharm=true -PbuildProfile=p231
+./gradlew clean buildPlugin runIde -PbuildWithPycharm=true -PbuildProfile=p232
 
 ######################  pycharm pro
 
 ./gradlew clean buildPlugin -PbuildWithPycharmPro=true
-./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=p232
 
 ## to run ide from command line
 ./gradlew clean buildPlugin runIde -PbuildWithPycharmPro=true
-./gradlew clean buildPlugin runIde -PbuildWithPycharmPro=true -PbuildProfile=latest
-./gradlew clean buildPlugin runIde -PbuildWithPycharmPro=true -PbuildProfile=eap
+./gradlew clean buildPlugin runIde -PbuildWithPycharmPro=true -PbuildProfile=p231
+./gradlew clean buildPlugin runIde -PbuildWithPycharmPro=true -PbuildProfile=p232

--- a/building-how-to/build-all-profiles.sh
+++ b/building-how-to/build-all-profiles.sh
@@ -6,36 +6,48 @@
 set -e
 ###################   idea community
 
-# there is no need to send the lowest profile, its the default if not sent,its here just as example
+# there is no need to send the oldest profile, its the default if not sent,its here just as example
 
+## check that profile aliases work
 ./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=lowest
 ./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=latest
 ./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=eap
 
 
+
+./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=p223
+./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=p231
+./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=p232
+./gradlew clean buildPlugin runPluginVerifier -PbuildProfile=p233
+
+
 ###################### idea ultimate
 
 ./gradlew clean buildPlugin runPluginVerifier -PbuildWIthUltimate=true
-./gradlew clean buildPlugin runPluginVerifier -PbuildWIthUltimate=true -PbuildProfile=latest
-./gradlew clean buildPlugin runPluginVerifier -PbuildWIthUltimate=true -PbuildProfile=eap
+./gradlew clean buildPlugin runPluginVerifier -PbuildWIthUltimate=true -PbuildProfile=p231
+./gradlew clean buildPlugin runPluginVerifier -PbuildWIthUltimate=true -PbuildProfile=p232
+./gradlew clean buildPlugin runPluginVerifier -PbuildWIthUltimate=true -PbuildProfile=p233
 
 
 
 #################  rider
 ./gradlew clean buildPlugin -PbuildWithRider=true
-./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=p232
+./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=p233
 
 ######################  pycharm
 
 ./gradlew clean buildPlugin -PbuildWithPycharm=true
-./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=p232
+./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=p233
 
 
 ######################  pycharm pro
 
 ./gradlew clean buildPlugin -PbuildWithPycharmPro=true
-./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=latest
-./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=p231
+./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=p232
+./gradlew clean buildPlugin -PbuildWithPycharmPro=true -PbuildProfile=p233
 

--- a/building-how-to/building-how-to.txt
+++ b/building-how-to/building-how-to.txt
@@ -1,18 +1,94 @@
 
 
-see build-all.sh for examples.
+see build-all-examples.sh and build-all-profiles.sh for examples.
+
+## Motivation
+###########################################################
+the motivation is to be able to build for different intellij releases without maintaining branches.
+
+Note:
+The build profiles require constant maintenance. when a new intellij patch is released we need to update
+the corresponding profile so that we use the latest patch when building and testing.
+EAP profile requires constant maintenance as new snapshots are released.
+Rider and rd-gen require updating as new rd-gen versions are released.
+etc.
+this is a work that never ends.
+
 
 
 ## Build
 ############################################################
 
-the project can build 3 profiles: lowest, latest and eap.
+the project can build few profiles, each profile correspond to an intellij release, for example: p223, p231, p232
 
-the motivation is to be able to build for different intellij releases without maintaining branches.
+the profile names are the first 3 digits of intellij build number with a 'p' prefix. intellij build numbers
+always start with 3 digits that correspond to the major release.
+for example:
+builds of release 2022.3 will start with 223.xxx.xxx, and also all patches like 2022.3.1,2022.3.2 etc.
+builds of release 2023.2 will start with 232.xxx.xxx
 
-lowest build with the lowest version supported, for example 2022.3.1
-latest builds for the latest intellij release, for example 2023.1.3
-eap build for the EAP version, for example 2023.2
+the profile for EAP will be the same format, for example if the next EAP is 2023.3 the profile name will be p233.
+
+
+## Adding Profiles
+#############################################################
+when a new intellij version start,usually with EAP builds, we should add a profile for the EAP. adding a profile
+for EAP is a bit more difficult, not all products have the same build numbers and snapshots, and sometimes it takes time
+to find all the relevant information. EAP requires constant maintenance every few days because new snapshots are released
+almost every day.
+the EAP profile is marked with isEAP = true.
+when EAP is releases the profile needs to be updated to the release versions and marked isEAP = false.
+Note that EAP build may fail often, so it needs constant care to make sure our github workflows don't fail.
+
+to add a profile:
+in buildSrc/src/main/kotlin/common/BuildProfile.kt:
+ add the new profile to the Profiles enum.
+ add the profile to the profiles map.
+in building-how-to/build-all-profiles.sh:
+ add build lines for the new profile.
+in .github/workflows
+ fine all root workflows that have a matrix strategy with the list of profiles and add the new profile.
+add new run configurations for the new profile.
+
+## Removing old profiles
+#############################################################
+as new releases come out, older versions become more difficult to maintain because of API changes or build system changes,
+sometimes new releases require changes in gradle build scripts that will not work with older versions.
+we try to keep support for as many releases as possible without too much work. if it becomes too difficult to support
+older releases we can remove the oldest profiles.
+we must support at least 2 versions plus the next EAP.
+
+to remove a profile do the revers of adding a profile.
+
+
+## Profile aliases
+############################################################
+There are convenient aliases for building the lowest, latest or eap profiles.
+./gradlew clean buildPlugin -PbuildProfile=lowest
+./gradlew clean buildPlugin -PbuildProfile=latest
+./gradlew clean buildPlugin -PbuildProfile=eap
+
+
+
+## Run configurations
+##############################################################
+There is a run configuration for each profile that can be used to test the plugin with the different intellij release.
+there are run configuration for all the products we support and every release we support.
+
+There is a special run configuration for EAP that uses profile alias.
+
+
+
+## Rider notes
+##############################################################
+rider uses the library rd-gen which should be different version for each IDE version.
+see in settings.gradle.kts
+need to map the profile name to a suitable rd-gen version and also support the correct profile alias lowest,latest,eap.
+
+
+
+## How to use
+##############################################################
 
 profiles are declared in buildSrc/src/main/kotlin/common/BuildProfile.kt
 a profile holds a few properties for the project, mainly platformVersion,riderVersion and more.
@@ -36,21 +112,22 @@ data class BuildProfile(
 a profile is activated by a gradle property: buildProfile=[PROFILE]
 
 for example:
-./gradlew clean buildPlugin -PbuildProfile=latest
+./gradlew clean buildPlugin -PbuildProfile=p223
 or
-./gradlew clean buildPlugin -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildProfile=p232
 
-when there is no profile the lowest profile is active.
+when there is no profile the oldest release profile is active.
 
 
 ## How to build
 ############################################################
 
-If you built the project with lowest profile, and now you want to build with latest its necessary to clean before mainly
+If you built the project with p223 profile, and now you want to build with p232 its necessary to clean before, mainly
 because of some leftovers from previous build.
 so a workflow could be something like:
 you start a branch for some feature, do a clean build. form now on you work as usual. if you now want to
-build and test with latest or eap, do a clean build again.
+build and test with p231 or p232, do a clean build again.
+
 
 
 
@@ -73,19 +150,19 @@ RD=rider
 
 the plugin version is in version.properties and is the base plugin version, for example 2.0.90.
 the final plugin zip will have a version that includes the intellij release code,
-for example: 2.0.90.231, this is the version in plugin.xml.
+for example: 2.0.90+231, this is the version in plugin.xml.
 this code is also used in sinceBuild=232 untilBuild=232.* in plugin.xml.
 
-so 2.0.90.223 can be installed on 2022.3.*
-and 2.0.90.231 can be installed on 2023.1.*
-and 2.0.90.232 can be installed on 2023.2.*
+so 2.0.90+223 can be installed on 2022.3.*
+and 2.0.90+231 can be installed on 2023.1.*
+and 2.0.90+232 can be installed on 2023.2.*
 
 
 
 ## Build with specific IDE:
 ############################################################
 
-besides the profile the build supports building with specific IDE.
+besides the profiles, the build supports building with specific IDE.
 usually a plugin can be built with the base platform , in our plugin, ide-common compiles
 with the base platform. rider module compiles with rider, python compiles with idea+python plugin.
 
@@ -97,13 +174,13 @@ buildWithPycharm
 buildWithPycharmPro
 if not supplied the default is IC
 
-when supplied then some modules will compile with the supplied IDE, ide-common and the main root module.
+when supplied, then some modules will compile with the supplied IDE, ide-common and the main root module.
 this can be used instead of running plugin verifier.
 
 for example:
-./gradlew clean buildPlugin -PbuildWIthUltimate=true -PbuildProfile=latest
+./gradlew clean buildPlugin -PbuildWIthUltimate=true -PbuildProfile=p232
 or
-./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=eap
+./gradlew clean buildPlugin -PbuildWithRider=true -PbuildProfile=p232
 
 
 
@@ -111,11 +188,11 @@ or
 ############################################################
 
 when buildProfile is activated it changes versions only for the build, your project in the IDE still compiles
-with the lowest profile.
-its possible to load a different platfor version in the IDE.
+with the oldest profile.
+it's possible to load a different platform version in the IDE.
 for example to load the latest version in Idea, add in gradle.properties
 
-buildProfile=latest/eap
+buildProfile=p232
 
 that will load the profile dependencies to idea, doing that you can develop with another intellij version.
 
@@ -149,7 +226,7 @@ using JetBrains.RdBackend.Common.Features;
 
 
 in kotlin/java it is probably possible to do things with reflection for different intellij versions.
-pr use different source base, or additional source bases.
+or use different source base, or additional source bases.
 currently there was no need, but solutions are there.
 
 
@@ -162,8 +239,8 @@ and it's also possible to launch an IDE from command line:
 see build-all.sh for examples.
 
 for example:
-./gradlew clean buildPlugin runIde -PbuildWithRider=true -PbuildProfile=eap
-./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=eap
+./gradlew clean buildPlugin runIde -PbuildWithRider=true -PbuildProfile=p232
+./gradlew clean buildPlugin -PbuildWithPycharm=true -PbuildProfile=p232
 
 if you run for example idea latest and now want to run rider eap a clean is necessary.
 
@@ -176,9 +253,8 @@ to download and install for specific IDE find the corresponding workflow and dow
 
 the publish workflow runs 3 times when releasing and publishes 3 versions to marketplace.
 for example:
-2.0.93.223
-2.0.93.231
-2.0.93.232
+2.0.93+223
+2.0.93+231
+2.0.93+232
 
-the base plugin version is bumped tp 2.0.93.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,8 +8,8 @@ pluginRepositoryUrl=https://github.com/digma-ai/digma-intellij-plugin.git
 ######### Build profiles
 ##build profiles
 ##change build profile to load the profile dependencies in the IDE. refresh gradle after change.
-#buildProfile=latest
-#buildProfile=eap
+#buildProfile=p231
+#buildProfile=p232
 ##build with real ide, will load the ide dependencies in the project. refresh gradle after change.
 #buildWithRider
 #buildWIthUltimate

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,8 +17,9 @@ pluginManagement {
                 val rdGenVersion = if (settings.providers.gradleProperty("buildProfile").isPresent) {
                     val profile = settings.providers.gradleProperty("buildProfile").get()
                     when (profile) {
-                        "latest" -> "2023.2.0"
-                        "eap" -> "2023.2.2"
+                        "p231" -> "2023.2.0"
+                        "p232", "latest" -> "2023.2.2"
+                        "p233", "eap" -> "2023.2.2"
                         else -> "2023.2.0"
                     }
                 } else {


### PR DESCRIPTION
new build profiles names:
the build profiles names are changed to correspond to the intellij release version.
read building-how-to/building-how-to.txt for information.

in short:
./gradlew clean buildPlugin -PbuildProfile=p223
./gradlew clean buildPlugin -PbuildProfile=p231
./gradlew clean buildPlugin -PbuildProfile=p232
./gradlew clean buildPlugin -PbuildProfile=p233

there are 3 aliases you can use to build the lowest, latest or eap profile
./gradlew clean buildPlugin -PbuildProfile=lowest
./gradlew clean buildPlugin -PbuildProfile=latest
./gradlew clean buildPlugin -PbuildProfile=eap

EAP profile, currently p233, is not active yet and not built in github, it will currently build with same versions as p232.
will be updated soon to build the next EAP 2023.3.