### PR TITLE
Bug fix/downloading OTEL agent version 1.29.0 instead of latest

### DIFF
--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -31,7 +31,8 @@ tasks{
     val downloadOtelJars = register("downloadOtelJars",Download::class.java){
         src(
             listOf(
-                "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar",
+//              "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar",
+                "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.29.0/opentelemetry-javaagent.jar",
                 "https://github.com/digma-ai/otel-java-instrumentation/releases/latest/download/digma-otel-agent-extension.jar")
         )
 

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/OTELJarProvider.kt
@@ -14,7 +14,8 @@ import kotlin.io.path.deleteIfExists
 private const val JARS_DIR_PREFIX = "digma-otel-jars"
 private const val RESOURCE_LOCATION = "otelJars"
 private const val OTEL_AGENT_JAR_URL =
-    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar"
+//  "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar"
+    "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v1.29.0/opentelemetry-javaagent.jar"
 private const val DIGMA_AGENT_EXTENSION_JAR_URL =
     "https://github.com/digma-ai/otel-java-instrumentation/releases/latest/download/digma-otel-agent-extension.jar"
 private const val OTEL_AGENT_JAR_NAME = "opentelemetry-javaagent.jar"


### PR DESCRIPTION
seems like [OTEL Agent version 1.30.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.30.0) creates some regression to our Java extension, and method (code object) of Spring Endpoints are not being recorded as usual 