### PR TITLE
Feature/QuarkusTests - configure tests to reduce batching impact

### DIFF
--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/QuarkusRunConfigurationWrapper.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/runcfg/QuarkusRunConfigurationWrapper.kt
@@ -122,6 +122,15 @@ class QuarkusRunConfigurationWrapper : RunConfigurationWrapper {
             retVal = retVal
                 .plus("-Dquarkus.otel.resource.attributes=\"$envPart\"")
                 .plus(" ")
+
+            // handle batching - try to remove them, so spans would manage to be sent out
+            retVal = retVal
+                .plus("-Dquarkus.otel.bsp.schedule.delay=1") // set delay to 1 milliseconds
+                .plus(" ")
+                .plus("-Dquarkus.otel.bsp.export.timeout=1") // set timeout to 1 milliseconds
+                .plus(" ")
+                .plus("-Dquarkus.otel.bsp.max.export.batch.size=1") // by setting size of 1 it kind of disable
+                .plus(" ")
         }
 
         return retVal


### PR DESCRIPTION
reduce the batching size and timeout so traces would manage to go out.

addresses issue #1338 - Summary A.
based on [quarkus guide](https://quarkus.io/guides/opentelemetry#quarkus-opentelemetry_quarkus.otel.bsp.max.queue.size)

seeing it solves the problem for quarkus version **3.2.6** 

in version 2.16 cannot affect those params
and in version 3.4.1 seeing some problem (see [details in a dedicated comment](https://github.com/digma-ai/digma-intellij-plugin/pull/1341#issuecomment-1742701500))

### how to reproduce:
1. go to git repo:
https://github.com/quarkusio/quarkus-quickstarts/tree/main/opentelemetry-quickstart

2. run test class (annotated with **QuarkusTest** )
https://github.com/quarkusio/quarkus-quickstarts/blob/main/opentelemetry-quickstart/src/test/java/org/acme/opentelemetry/TracedResourceTest.java
