### PR TITLE
Feature/spring boot micrometer tracing - support add env

### DIFF
--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
@@ -38,7 +38,7 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
         val DatasourceMicrometerSpringBoot = UnifiedCoordinates("net.ttddyy.observation", "datasource-micrometer-spring-boot", "1.0.2")
         val OtelExporterOtlpCoordinates = UnifiedCoordinates("io.opentelemetry", "opentelemetry-exporter-otlp", "1.26.0")
         val DigmaSpringBootMicrometerAutoconfCoordinates =
-            UnifiedCoordinates("io.github.digma-ai", "digma-spring-boot-micrometer-tracing-autoconf", "0.7.4")
+            UnifiedCoordinates("io.github.digma-ai", "digma-spring-boot-micrometer-tracing-autoconf", "0.7.7")
 
         @JvmStatic
         fun getInstance(project: Project): SpringBootMicrometerConfigureDepsService {

--- a/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
+++ b/java/src/main/kotlin/org/digma/intellij/plugin/idea/frameworks/SpringBootMicrometerConfigureDepsService.kt
@@ -45,6 +45,10 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
             return project.getService(SpringBootMicrometerConfigureDepsService::class.java)
         }
 
+        @JvmStatic
+        fun isSpringBootWithMicrometer(): Boolean =
+            SettingsState.getInstance().springBootObservabilityMode == SpringBootObservabilityMode.Micrometer
+
         fun getSpringBootStarterActuatorDependency(javaBuildSystem: JavaBuildSystem, springBootVersion: String): UnifiedDependency {
             val libCoordinates = UnifiedCoordinates("org.springframework.boot", "spring-boot-starter-actuator", springBootVersion)
 
@@ -196,9 +200,6 @@ class SpringBootMicrometerConfigureDepsService(private val project: Project) : D
 
         return stateHasSpringBootModulesWithoutObservability.get()
     }
-
-    fun isSpringBootWithMicrometer(): Boolean =
-        SettingsState.getInstance().springBootObservabilityMode == SpringBootObservabilityMode.Micrometer
 
     fun buttonClicked() {
         // start blackout time that panel won't be display

--- a/src/main/kotlin/org/digma/intellij/plugin/ui/recentactivity/AddEnvironmentsService.kt
+++ b/src/main/kotlin/org/digma/intellij/plugin/ui/recentactivity/AddEnvironmentsService.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemRunConfiguration
 import com.intellij.openapi.project.Project
+import kotlinx.collections.immutable.toImmutableMap
 import org.digma.intellij.plugin.errorreporting.ErrorReporter
 import org.digma.intellij.plugin.idea.deps.ModulesDepsService
 import org.digma.intellij.plugin.idea.frameworks.SpringBootMicrometerConfigureDepsService
@@ -200,43 +201,25 @@ class AddEnvironmentsService {
         return when (config) {
             is CommonProgramRunConfigurationParameters -> {
                 Log.log(logger::info, "adding environment to configuration {}", config.name)
-                try {
-                    config.envs["OTEL_RESOURCE_ATTRIBUTES"] = "digma.environment=$environment"
-                } catch (e: Exception) {
-                    Log.log(logger::info, "failed adding environment to configuration {},{}, trying to replace map", config.name, e)
-                    val map = mutableMapOf<String, String>()
-                    map.putAll(config.envs)
-                    addEnvToMap(map, environment)
-                    config.envs = map
-                }
+                config.envs = config.envs.toImmutableMap()
+                config.envs[envVarKey] = envVarValue
+
                 true
             }
 
             is ExternalSystemRunConfiguration -> {
                 Log.log(logger::info, "adding environment to configuration {}", config.name)
-                try {
-                    config.settings.env["OTEL_RESOURCE_ATTRIBUTES"] = "digma.environment=$environment"
-                } catch (e: Exception) {
-                    Log.log(logger::info, "failed adding environment to configuration {},{}, trying to replace map", config.name, e)
-                    val map = mutableMapOf<String, String>()
-                    map.putAll(config.settings.env)
-                    addEnvToMap(map, environment)
-                    config.settings.env = map
-                }
+                config.settings.env = config.settings.env.toImmutableMap()
+                config.settings.env[envVarKey] = envVarValue
+
                 true
             }
 
             is AbstractRunConfiguration -> {
                 Log.log(logger::info, "adding environment to configuration {}", config.name)
-                try {
-                    config.envs["OTEL_RESOURCE_ATTRIBUTES"] = "digma.environment=$environment"
-                } catch (e: Exception) {
-                    Log.log(logger::info, "failed adding environment to configuration {},{}, trying to replace map", config.name, e)
-                    val map = mutableMapOf<String, String>()
-                    map.putAll(config.envs)
-                    addEnvToMap(map, environment)
-                    config.envs = map
-                }
+                config.envs = config.envs.toImmutableMap()
+                config.envs[envVarKey] = envVarValue
+
                 true
             }
 


### PR DESCRIPTION
fixes #1456 .

relying on auto conf PR
https://github.com/digma-ai/otel-java-instrumentation/pull/32

which allow setting `MANAGEMENT_OPENTELEMETRY_RESOURCE-ATTRIBUTES` cross spring boot versions 3.0.x 3.1.x and 3.2.x

the JAR is `digma-spring-boot-micrometer-tracing-autoconf` is at version 0.7.7

