### PR TITLE
Bug fix/methodCodeObjectId is nullable

### DIFF
--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanFlow.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/insights/SpanFlow.kt
@@ -23,7 +23,7 @@ constructor(
     constructor(
         val service: String,
         val span: String,
-        val codeObjectId: String,
+        val codeObjectId: String?, // methodCodeObjectId
         val spanCodeObjectId: String
     )
 

--- a/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/recentactivity/RecentActivityResult.kt
+++ b/model/src/main/kotlin/org/digma/intellij/plugin/model/rest/recentactivity/RecentActivityResult.kt
@@ -46,7 +46,7 @@ constructor(
         val serviceName: String,
         val scopeId: String,
         val spanCodeObjectId: String,
-        val methodCodeObjectId: String
+        val methodCodeObjectId: String?
 )
 
 data class SlimAggregatedInsight


### PR DESCRIPTION
part of PR https://github.com/digma-ai/digma-collector-backend/pull/1442/files
found out that `methodCodeObjectId` should be nullable instead of possible empty string