### PR TITLE
Fixed bug where only git@github.com links were supported

### DIFF
--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/vcs/VcsService.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/vcs/VcsService.kt
@@ -134,7 +134,7 @@ class VcsService(project: Project) : BaseVcsService(project) {
                 val url = GitUtil.getDefaultRemote(repository.remotes)?.firstUrl
                     ?: return@executeOnPooledThread null
 
-                if (!url.startsWith("git@github.com")) {
+                if (!url.startsWith("git@github.com") && !url.startsWith("https://github.com/")) {
                     return@executeOnPooledThread null
                 }
 


### PR DESCRIPTION
Expected behavior: also support HTTP links