### PR TITLE
dont use jetbrains vendor in toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
+import common.BuildProfiles
 import common.buildVersion
+import common.currentProfile
 import common.dynamicPlatformType
 import common.logBuildProfile
 import common.platformPlugins
@@ -245,6 +247,24 @@ tasks {
             //make large idea.log because the default rotates every 10M and makes it difficult to follow messages with tail
             "idea.log.limit" to "999999999"
         )
+
+
+        //todo: this is a workaround for these issues:
+        // 241 should run with JBR 21. but currently there is a bug in gradle-intellij-plugin that downloads
+        // a 21 JBR without jcef support.
+        // see this issue:
+        // https://github.com/JetBrains/gradle-intellij-plugin/issues/1534
+        // and this PR fixes it
+        // https://github.com/JetBrains/gradle-intellij-plugin/pull/1535
+        // when gradle-intellij-plugin has a new release including the above fix it will download the right 21 JBR.
+        // but then there is this issue:
+        // https://github.com/digma-ai/digma-intellij-plugin/issues/1734
+        // if 241 runs with 21 then gradle-intellij-plugin will configure the test task to use this JBR,
+        // but some of our tests fail with 21. so we have to make sure all our tests pass with JBR 21
+        // before removing this workaround.
+        if (project.currentProfile().profile == BuildProfiles.Profiles.p241) {
+            jbrVersion = "17.0.10b1087.17"
+        }
     }
 
 

--- a/buildSrc/src/main/kotlin/common-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-java.gradle.kts
@@ -8,24 +8,15 @@ plugins {
 }
 
 java {
-    @Suppress("UnstableApiUsage")
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(project.currentProfile().javaVersion))
         //it is possible to use jetbrains runtime for toolchain but then
         // runIde will use this runtime to run the development instance and that is not ideal,
         // it's better to run the development instance with the bundled runtime.
+        // so IMO its not a good idea to configure 'vendor = JvmVendorSpec.JETBRAINS'
+        // follow this issue: https://github.com/JetBrains/gradle-intellij-plugin/issues/1538
 
-        //todo: but because of this issue
-        // https://github.com/JetBrains/gradle-intellij-plugin/issues/1534
-        // we currently must run the 241 development instance with JBR 17, until the issue is fixed
-        // another issue is that runIde changes the test task executable to the bundled JBR, so when
-        // building with 241 some of our tests will fail.
-
-        vendor = JvmVendorSpec.JETBRAINS
-
-        //there is not real need for vendor, any jdk should compile the project correctly.
-        //amazon is recommended by jetbrains
-        //vendor = JvmVendorSpec.IBM
+        vendor = JvmVendorSpec.AMAZON
     }
 }
 

--- a/buildSrc/src/main/kotlin/common-kotlin.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-kotlin.gradle.kts
@@ -21,24 +21,12 @@ plugins {
 }
 
 kotlin {
-    @Suppress("UnstableApiUsage")
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(project.currentProfile().javaVersion))
-        //it is possible to use jetbrains runtime for toolchain but then
-        // runIde will use this runtime to run the development instance and that is not ideal,
-        // it's better to run the development instance with the bundled runtime.
+        //don't configure 'vendor = JvmVendorSpec.JETBRAINS'
+        // see this issue: https://github.com/JetBrains/gradle-intellij-plugin/issues/1538
 
-        //todo: but because of this issue
-        // https://github.com/JetBrains/gradle-intellij-plugin/issues/1534
-        // we currently must run the 241 development instance with JBR 17, until the issue is fixed
-        // another issue is that runIde changes the test task executable to the bundled JBR, so when
-        // building with 241 some of our tests will fail.
-
-        vendor = JvmVendorSpec.JETBRAINS
-
-        //there is not real need for vendor, any jdk should compile the project correctly.
-        //amazon is recommended by jetbrains
-        //vendor = JvmVendorSpec.IBM
+        vendor = JvmVendorSpec.AMAZON
     }
 }
 


### PR DESCRIPTION
this PR solves this issue
https://github.com/JetBrains/gradle-intellij-plugin/issues/1538

and these

//todo: this is a workaround for these issues:
        // 241 should run with JBR 21. but currently there is a bug in gradle-intellij-plugin that downloads
        // a 21 JBR without jcef support.
        // see this issue:
        // https://github.com/JetBrains/gradle-intellij-plugin/issues/1534
        // and this PR fixes it
        // https://github.com/JetBrains/gradle-intellij-plugin/pull/1535
        // when gradle-intellij-plugin has a new release including the above fix it will download the right 21 JBR.
        // but then there is this issue:
        // https://github.com/digma-ai/digma-intellij-plugin/issues/1734
        // if 241 runs with 21 then gradle-intellij-plugin will configure the test task to use this JBR,
        // but some of our tests fail with 21. so we have to make sure all our tests pass with JBR 21
        // before removing this workaround.
        if (project.currentProfile().profile == BuildProfiles.Profiles.p241) {
            jbrVersion = "17.0.10b1087.17"
        }