### PR TITLE
extended-observability-experiment

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -249,6 +249,18 @@ tasks {
             "org.digma.plugin.enable.devtools" to "true",
 
 //            "idea.ProcessCanceledException" to "disabled"
+
+
+            //to use a local file for digma-agent or digma extension,
+            // usually when developing and we want to test the plugin
+            //see org.digma.intellij.plugin.idea.execution.OtelAgentPathProvider
+            //don't forget to comment when done testing !
+            //"digma.agent.override.path" to "/home/shalom/workspace/digma/digma-agent/build/libs/digma-agent-1.0.2.jar"
+            //"digma.otel.extension.override.path" to "/home/shalom/workspace/digma/otel-java-instrumentation/agent-extension/build/libs/digma-otel-agent-extension-0.8.12.jar"
+            //can also change the url from where the jar is downloaded when IDE starts
+            //"org.digma.otel.extensionUrl" to "some url
+            //"org.digma.otel.digmaAgentUrl" to "some url
+
         )
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,7 +255,7 @@ tasks {
             // usually when developing and we want to test the plugin
             //see org.digma.intellij.plugin.idea.execution.OtelAgentPathProvider
             //don't forget to comment when done testing !
-            //"digma.agent.override.path" to "/home/shalom/workspace/digma/digma-agent/build/libs/digma-agent-1.0.2.jar"
+            //"digma.agent.override.path" to "/home/shalom/workspace/digma/digma-agent/build/libs/digma-agent-1.0.8-SNAPSHOT.jar"
             //"digma.otel.extension.override.path" to "/home/shalom/workspace/digma/otel-java-instrumentation/agent-extension/build/libs/digma-otel-agent-extension-0.8.12.jar"
             //can also change the url from where the jar is downloaded when IDE starts
             //"org.digma.otel.extensionUrl" to "some url

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -255,7 +255,7 @@ tasks {
             // usually when developing and we want to test the plugin
             //see org.digma.intellij.plugin.idea.execution.OtelAgentPathProvider
             //don't forget to comment when done testing !
-            //"digma.agent.override.path" to "/home/shalom/workspace/digma/digma-agent/build/libs/digma-agent-1.0.8-SNAPSHOT.jar"
+            //"digma.agent.override.path" to "/home/shalom/workspace/digma/digma-agent/build/libs/digma-agent-1.0.10-SNAPSHOT.jar"
             //"digma.otel.extension.override.path" to "/home/shalom/workspace/digma/otel-java-instrumentation/agent-extension/build/libs/digma-otel-agent-extension-0.8.12.jar"
             //can also change the url from where the jar is downloaded when IDE starts
             //"org.digma.otel.extensionUrl" to "some url

--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/ProjectSettings.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/ProjectSettings.java
@@ -46,7 +46,8 @@ public class ProjectSettings implements Configurable {
                 isJaegerLinkModeChanged(settings) ||
                 isSpringBootObservabilityModeChanged(settings) ||
                 isRuntimeObservabilityBackendUrlChanged(settings) ||
-                isExtendedObservabilityChanged(settings);
+                isExtendedObservabilityChanged(settings) ||
+                isExtendedObservabilityExcludeChanged(settings);
     }
 
     private boolean isRefreshDelayChanged(SettingsState settings) {
@@ -83,6 +84,10 @@ public class ProjectSettings implements Configurable {
 
     private boolean isExtendedObservabilityChanged(SettingsState settings) {
         return !Objects.equals(settings.extendedObservability, mySettingsComponent.getExtendedObservability());
+    }
+
+    private boolean isExtendedObservabilityExcludeChanged(SettingsState settings) {
+        return !Objects.equals(settings.extendedObservabilityExcludes, mySettingsComponent.getExtendedObservabilityExclude());
     }
 
     @Override
@@ -149,6 +154,7 @@ public class ProjectSettings implements Configurable {
         settings.springBootObservabilityMode = mySettingsComponent.getSpringBootObservabilityMode();
         settings.runtimeObservabilityBackendUrl = mySettingsComponent.getRuntimeObservabilityBackendUrl();
         settings.extendedObservability = mySettingsComponent.getExtendedObservability();
+        settings.extendedObservabilityExcludes = mySettingsComponent.getExtendedObservabilityExclude();
         settings.fireChanged();
     }
 
@@ -164,6 +170,7 @@ public class ProjectSettings implements Configurable {
         mySettingsComponent.setSpringBootObservabilityMode(settings.springBootObservabilityMode);
         mySettingsComponent.setRuntimeObservabilityBackendUrl(settings.runtimeObservabilityBackendUrl);
         mySettingsComponent.setExtendedObservability(settings.extendedObservability);
+        mySettingsComponent.setExtendedObservabilityExclude(settings.extendedObservabilityExcludes);
     }
 
 

--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsComponent.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsComponent.java
@@ -30,8 +30,13 @@ public class SettingsComponent {
     private final JBLabel myRuntimeObservabilityBackendUrlLabel = new JBLabel("Runtime observability backend URL:");
     private final JBTextField myRuntimeObservabilityBackendUrlText = new JBTextField();
     private final JBTextField extendedObservabilityTextBox = new JBTextField();
+    private final JBTextField extendedObservabilityExcludeTextBox = new JBTextField();
 
     public SettingsComponent() {
+
+        extendedObservabilityTextBox.setToolTipText("packages names in format 'my.pkg1;my.pkg2");
+        extendedObservabilityExcludeTextBox.setToolTipText("class/method names to exclude in format 'MyClass;MyOtherClass.myOtherMethod;*get");
+
 
         var defaultLabelForeground = JBColor.foreground();
 
@@ -156,6 +161,7 @@ public class SettingsComponent {
                 .addLabeledComponent(mySpringBootObservabilityModeLabel, mySpringBootObservabilityModeComboBox, 1, false)
                 .addLabeledComponent(myRuntimeObservabilityBackendUrlLabel, myRuntimeObservabilityBackendUrlText, 1, false)
                 .addLabeledComponent("Extended Observability (beta)", extendedObservabilityTextBox, 1, false)
+                .addLabeledComponent("Extended Observability Exclude (beta)", extendedObservabilityExcludeTextBox, 1, false)
                 .addComponent(resetButton)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
@@ -278,6 +284,16 @@ public class SettingsComponent {
         return extendedObservabilityTextBox.getText();
     }
 
+    public void setExtendedObservabilityExclude(@Nullable String extendedObservabilityExclude) {
+        extendedObservabilityExcludeTextBox.setText(extendedObservabilityExclude);
+    }
+
+    @Nullable
+    public String getExtendedObservabilityExclude() {
+        return extendedObservabilityExcludeTextBox.getText();
+    }
+
+
     private void resetToDefaults() {
         this.setApiUrlText(SettingsState.DEFAULT_API_URL);
         this.setApiToken(null);
@@ -289,5 +305,6 @@ public class SettingsComponent {
         this.setSpringBootObservabilityMode(SettingsState.DEFAULT_SPRING_BOOT_OBSERVABILITY_MODE);
         this.setRuntimeObservabilityBackendUrl(SettingsState.DEFAULT_RUNTIME_OBSERVABILITY_BACKEND_URL);
         this.setExtendedObservability(null);
+        this.setExtendedObservabilityExclude(null);
     }
 }

--- a/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsState.java
+++ b/ide-common/src/main/java/org/digma/intellij/plugin/settings/SettingsState.java
@@ -51,6 +51,8 @@ public class SettingsState implements PersistentStateComponent<SettingsState>, D
     public String posthogToken;
     @Nullable
     public String extendedObservability;
+    @Nullable
+    public String extendedObservabilityExcludes;
 
 
     private final List<SettingsChangeListener> listeners = new ArrayList<>();

--- a/ide-common/src/main/kotlin/org/digma/intellij/plugin/posthog/SettingsChangeTracker.kt
+++ b/ide-common/src/main/kotlin/org/digma/intellij/plugin/posthog/SettingsChangeTracker.kt
@@ -77,6 +77,7 @@ class SettingsChangeTracker {
         myTrackedSettings["refreshDelay"] = SettingsState.getInstance().refreshDelay.toString()
         myTrackedSettings["springBootObservabilityMode"] = SettingsState.getInstance().springBootObservabilityMode.name
         myTrackedSettings["extendedObservability"] = SettingsState.getInstance().extendedObservability.toString()
+        myTrackedSettings["extendedObservabilityExcludes"] = SettingsState.getInstance().extendedObservabilityExcludes.toString()
     }
 
 

--- a/jvm-common/build.gradle.kts
+++ b/jvm-common/build.gradle.kts
@@ -39,14 +39,29 @@ tasks {
         src(
             listOf(
                 properties.getProperty("otel-agent"),
-                properties.getProperty("digma-extension")
+                properties.getProperty("digma-extension"),
+                properties.getProperty("digma-agent")
             )
         )
 
-        logger.lifecycle("copying jars $properties")
+        logger.lifecycle("jars to download $properties")
 
         dest(File(project.sourceSets.main.get().output.resourcesDir, "otelJars"))
         overwrite(true)
+        //if a jar is downloaded with version then its name needs to change. it may happen
+        // in development if the url for some of the jars is changed to download from somewhere else.
+        //usually latest jar is downloaded without version
+        eachFile {
+            name = if (name.startsWith("digma-otel-agent-extension", true)) {
+                "digma-otel-agent-extension.jar"
+            } else if (name.startsWith("digma-agent", true)) {
+                "digma-agent.jar"
+            } else if (name.startsWith("opentelemetry-javaagent", true)) {
+                "opentelemetry-javaagent.jar"
+            } else {
+                name
+            }
+        }
     }
 
     processResources {

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/JavaParametersMerger.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/JavaParametersMerger.kt
@@ -95,9 +95,10 @@ open class JavaParametersMerger(
     protected fun smartMergeJavaToolOptions(myJavaToolOptions: String, currentJavaToolOptions: String): String {
 
         //merge two java tool options strings. values from myJavaToolOptions override values from currentJavaToolOptions
+        //we want to preserve the order , existing java tool options properties should be first
 
-        val myOptions = javaToolOptionsToMap(myJavaToolOptions)
         val currentOptions = javaToolOptionsToMap(currentJavaToolOptions)
+        val myOptions = javaToolOptionsToMap(myJavaToolOptions)
 
         val result = mutableMapOf<String, String?>()
         result.putAll(currentOptions)

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/JavaToolOptionsBuilder.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/JavaToolOptionsBuilder.kt
@@ -46,6 +46,8 @@ open class JavaToolOptionsBuilder(
                 throw JavaToolOptionsBuilderException("useAgent is true but can't find agent paths")
             }
             javaToolOptions
+                .append("-javaagent:${otelAgentPathProvider.digmaAgentPath}")
+                .append(" ")
                 .append("-javaagent:${otelAgentPathProvider.otelAgentPath}")
                 .append(" ")
                 .append("-Dotel.javaagent.extensions=${otelAgentPathProvider.digmaExtensionPath}")
@@ -145,6 +147,12 @@ open class JavaToolOptionsBuilder(
         if (!SettingsState.getInstance().extendedObservability.isNullOrBlank()) {
             javaToolOptions
                 .append("-Ddigma.autoinstrument.packages=${SettingsState.getInstance().extendedObservability}")
+                .append(" ")
+        }
+
+        if (!SettingsState.getInstance().extendedObservabilityExcludes.isNullOrBlank()) {
+            javaToolOptions
+                .append("-Ddigma.autoinstrument.packages.exclude.names=${SettingsState.getInstance().extendedObservabilityExcludes}")
                 .append(" ")
         }
         return this
@@ -254,7 +262,16 @@ open class JavaToolOptionsBuilder(
 
 
     open fun build(): String {
+        disableExtendedObservabilityExtension()
         return javaToolOptions.toString()
+    }
+
+    //todo: disabled in this branch because it uses Digma agent that injects @WithSpan instead of the
+    // digma-methods instrumentation module.
+    private fun disableExtendedObservabilityExtension() {
+        javaToolOptions
+            .append("-Dotel.instrumentation.digma-methods.enabled=false")
+            .append(" ")
     }
 
 

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/JavaToolOptionsBuilder.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/JavaToolOptionsBuilder.kt
@@ -57,6 +57,10 @@ open class JavaToolOptionsBuilder(
                 javaToolOptions
                     .append("-javaagent:${otelAgentPathProvider.digmaAgentPath}")
                     .append(" ")
+
+                withDigmaAgentDebug()
+
+
             }
 
             javaToolOptions
@@ -149,6 +153,18 @@ open class JavaToolOptionsBuilder(
         if (java.lang.Boolean.getBoolean("digma.otel.debug")) {
             javaToolOptions
                 .append("-Dotel.javaagent.debug=true")
+                .append(" ")
+        }
+        return this
+    }
+
+
+    open fun withDigmaAgentDebug(): JavaToolOptionsBuilder {
+        if (java.lang.Boolean.getBoolean("digma.agent.debug") ||
+            java.lang.Boolean.valueOf(System.getenv("DIGMA_AGENT_DEBUG"))
+        ) {
+            javaToolOptions
+                .append("-Ddigma.agent.debug=true")
                 .append(" ")
         }
         return this

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/OtelAgentPathProvider.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/OtelAgentPathProvider.kt
@@ -76,7 +76,11 @@ class OtelAgentPathProvider(configuration: RunConfiguration) {
 
 
     fun hasAgentPath(): Boolean {
-        return otelAgentPath != null && digmaExtensionPath != null && digmaAgentPath != null
+        return otelAgentPath != null && digmaExtensionPath != null
+    }
+
+    fun hasDigmaAgentPath(): Boolean {
+        return digmaAgentPath != null
     }
 
 }

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/OtelAgentPathProvider.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/OtelAgentPathProvider.kt
@@ -13,21 +13,30 @@ class OtelAgentPathProvider(configuration: RunConfiguration) {
 
     val otelAgentPath: String?
     val digmaExtensionPath: String?
+    val digmaAgentPath: String?
 
     init {
-        val tmpAgentPath = service<OTELJarProvider>().getOtelAgentJarPath()
-        val tmpDigmaExtensionPath = service<OTELJarProvider>().getDigmaAgentExtensionJarPath()
-        if (tmpAgentPath != null && tmpDigmaExtensionPath != null) {
+
+        //paths can be overrider with system properties for development purposes
+        val tmpOtelAgentPath = System.getProperty("digma.otel.agent.override.path", service<OTELJarProvider>().getOtelAgentJarPath())
+        val tmpDigmaExtensionPath =
+            System.getProperty("digma.otel.extension.override.path", service<OTELJarProvider>().getDigmaAgentExtensionJarPath())
+        val tmpDigmaAgentPath = System.getProperty("digma.agent.override.path", service<OTELJarProvider>().getDigmaAgentJarPath())
+
+        if (tmpOtelAgentPath != null && tmpDigmaExtensionPath != null && tmpDigmaAgentPath != null) {
             if (isWsl(configuration)) {
-                otelAgentPath = FileUtils.convertWinToWslPath(tmpAgentPath)
+                otelAgentPath = FileUtils.convertWinToWslPath(tmpOtelAgentPath)
                 digmaExtensionPath = FileUtils.convertWinToWslPath(tmpDigmaExtensionPath)
+                digmaAgentPath = FileUtils.convertWinToWslPath(tmpDigmaAgentPath)
             } else {
-                otelAgentPath = tmpAgentPath
+                otelAgentPath = tmpOtelAgentPath
                 digmaExtensionPath = tmpDigmaExtensionPath
+                digmaAgentPath = tmpDigmaAgentPath
             }
         } else {
             otelAgentPath = null
             digmaExtensionPath = null
+            digmaAgentPath = null
         }
 
     }
@@ -67,7 +76,7 @@ class OtelAgentPathProvider(configuration: RunConfiguration) {
 
 
     fun hasAgentPath(): Boolean {
-        return otelAgentPath != null && digmaExtensionPath != null
+        return otelAgentPath != null && digmaExtensionPath != null && digmaAgentPath != null
     }
 
 }

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/constants.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/constants.kt
@@ -12,6 +12,10 @@ const val OTEL_SERVICE_NAME_PROP_NAME = "otel.service.name"
 
 const val DIGMA_MARKER = "-Dorg.digma.marker=true"
 
+//a feature flag to use digma agent for extended instrumentation instead of the otel extension module
+const val USE_DIGMA_AGENT_PROP_NAME = "USE_DIGMA_AGENT"
+
+
 /*
 DIGMA_OBSERVABILITY is an environment variable to forces observability when user executes an unsupported
  gradle task or maven goal. it should be used only for gradle or maven. it can not force observability for unknown

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/constants.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/constants.kt
@@ -13,7 +13,8 @@ const val OTEL_SERVICE_NAME_PROP_NAME = "otel.service.name"
 const val DIGMA_MARKER = "-Dorg.digma.marker=true"
 
 //a feature flag to use digma agent for extended instrumentation instead of the otel extension module
-const val USE_DIGMA_AGENT_PROP_NAME = "USE_DIGMA_AGENT"
+//todo: delete, not used anymore
+//const val USE_DIGMA_AGENT_PROP_NAME = "USE_DIGMA_AGENT"
 
 
 /*

--- a/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/flavor/DefaultInstrumentationFlavor.kt
+++ b/jvm-common/src/main/kotlin/org/digma/intellij/plugin/idea/execution/flavor/DefaultInstrumentationFlavor.kt
@@ -118,7 +118,7 @@ open class DefaultInstrumentationFlavor : BaseInstrumentationFlavor() {
             val isTest = isTest(instrumentationService, parametersExtractor, configuration, params)
 
             javaToolOptionsBuilder
-                .withOtelAgent(useOtelAgent())
+                .withOtelAgent(useOtelAgent(), parametersExtractor)
                 .withMockitoSupport(isTest)
                 .withServiceName(moduleResolver, parametersExtractor, serviceNameProvider)
                 .withExtendedObservability()

--- a/jvm-common/src/main/resources/jars-urls.properties
+++ b/jvm-common/src/main/resources/jars-urls.properties
@@ -1,2 +1,3 @@
 otel-agent=https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v2.1.0/opentelemetry-javaagent.jar
 digma-extension=https://github.com/digma-ai/otel-java-instrumentation/releases/latest/download/digma-otel-agent-extension.jar
+digma-agent=https://github.com/digma-ai/digma-agent/releases/latest/download/digma-agent.jar


### PR DESCRIPTION
new way to do extended instrumentation using a java agent that injects @WithSpan annotations to methods instead of instrumentation the standard way with otel extension module.

digma-agent configuration
https://github.com/digma-ai/digma-agent/blob/4ff6e7a9fe3d2a32e827a0a8bfff380c6865a6d7/src/main/java/org/digma/Configuration.java


